### PR TITLE
Add OpenAI and local VLM vision model adapters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@
 # gracefully"). The pipeline runs with an empty .env; it just runs dumber.
 
 # --- Model provider: one provider powers the whole run (vision + narrative) ---
-# --- gemini (default) | openai. Do not mix providers in a single run. ---
+# --- gemini (default) | openai | local. Do not mix providers in a single run. ---
 MODEL_PROVIDER=gemini
 
 # --- Gemini (used when MODEL_PROVIDER=gemini) ---
@@ -17,6 +17,17 @@ GEMINI_MODEL=gemini-3.5-flash
 # cache keys fingerprint the model so ratings never silently reuse.
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-4.1-mini
+
+# --- Local OpenAI-compatible VLM (used when MODEL_PROVIDER=local) ---
+# Default URL is MLX-VLM. Ollama is often http://localhost:11434/v1;
+# LM Studio often http://localhost:1234/v1. Prefers json_schema structured
+# outputs; falls back to free-form JSON when the server rejects that format.
+# LOCAL_MAX_CONCURRENCY is process-wide (scanner builds one adapter per clip).
+LOCAL_BASE_URL=http://localhost:8080/v1
+LOCAL_API_KEY=local
+LOCAL_MODEL=
+LOCAL_MAX_CONCURRENCY=1
+LOCAL_TIMEOUT_SECONDS=600
 
 # --- Strava: segment popularity. Optional. ---
 # Register an app at https://www.strava.com/settings/api

--- a/.env.example
+++ b/.env.example
@@ -2,10 +2,21 @@
 # zones — each missing key just disables its feature (see README "Degrading
 # gracefully"). The pipeline runs with an empty .env; it just runs dumber.
 
-# --- Gemini: the vision scan. Without it, candidates come from telemetry ---
-# --- and Strava only, which is where the interesting moments aren't. ---
+# --- Model provider: one provider powers the whole run (vision + narrative) ---
+# --- gemini (default) | openai. Do not mix providers in a single run. ---
+MODEL_PROVIDER=gemini
+
+# --- Gemini (used when MODEL_PROVIDER=gemini) ---
+# Without a key, candidates come from telemetry and Strava only.
 GEMINI_API_KEY=
 GEMINI_MODEL=gemini-3.5-flash
+
+# --- OpenAI (used when MODEL_PROVIDER=openai) ---
+# Default is gpt-4.1-mini — current, vision-capable, cost-oriented for
+# high-volume frame scoring. Override OPENAI_MODEL to compare models;
+# cache keys fingerprint the model so ratings never silently reuse.
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4.1-mini
 
 # --- Strava: segment popularity. Optional. ---
 # Register an app at https://www.strava.com/settings/api

--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,14 @@ selected_candidates.json
 .claude/
 src/gopro_garmin_pipeline/design/proposals/
 .gemini_cache/
+.openai_cache/
 moments.json
 ride_labels.json
 
 # The published sample ride is the exception: its sidecars are committed so
 # the labels and baseline ratings are readable without downloading video.
 !samples/**/.gemini_cache/
+!samples/**/.openai_cache/
 !samples/**/moments.json
 !samples/**/ride_labels.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ selected_candidates.json
 src/gopro_garmin_pipeline/design/proposals/
 .gemini_cache/
 .openai_cache/
+.local_cache/
 moments.json
 ride_labels.json
 
@@ -32,6 +33,7 @@ ride_labels.json
 # the labels and baseline ratings are readable without downloading video.
 !samples/**/.gemini_cache/
 !samples/**/.openai_cache/
+!samples/**/.local_cache/
 !samples/**/moments.json
 !samples/**/ride_labels.json
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We identify compelling moments from four separate sources:
 
 1. Garmin telemetry via `.fit` file (speed, HR, power spikes, sprints, climbs)
 2. Strava via API (popular segments)
-3. Gemini vision scan + rating of individual frames
+3. Configured vision-model scan + rating of individual frames
 4. (optional) hand-labels via Streamlit app
 
 Here's an example of one moment being scored across all sources:
@@ -44,7 +44,7 @@ Here's an example of one moment being scored across all sources:
 The fusion step works like this:
 
 1. “Must include” manual labels are picked first
-2. A Gemini LLM narrative pass picks 20 clips to best tell the story of the ride, boosting “cross-source agreements” (if a human label + telemetry + Strava + Gemini all agree that a clip is interesting)
+2. A model narrative pass picks 20 clips to best tell the story of the ride, boosting “cross-source agreements” (if a human label + telemetry + Strava + vision all agree that a clip is interesting)
 3. Greedy re-ranking with a crowding penalty to avoid clips too close to something already selected
    1. First, a “quality” phase that picks best-first until the best remaining candidate is net-negative with crowding penalty
    2. Second, a “coverage” fill that guarantees the exact clip count by placing the liveliest available clips into the biggest timeline holes.
@@ -55,7 +55,9 @@ Generally, the visual rubric is the score of record, and telemetry is a tiebreak
 
 ## Setup
 
-**You need:** Python 3.11+, [ffmpeg](https://ffmpeg.org/download.html), and a Gemini API key. You also need a road bike mounted with a GoPro and a Garmin.
+**You need:** Python 3.11+, [ffmpeg](https://ffmpeg.org/download.html), and
+one configured vision-model provider. You also need a road bike mounted with a
+GoPro and a Garmin.
 
 ```bash
 git clone https://github.com/ianmacomber/ride-recap.git
@@ -68,7 +70,7 @@ pip install -e ".[dev]"
 cp .env.example .env
 ```
 
-Then open `.env` and set three things:
+Gemini is the default provider. To use it, open `.env` and set:
 
 ```env
 GEMINI_API_KEY=your-key-here    # https://aistudio.google.com/apikey
@@ -77,7 +79,10 @@ FTP=240                          # ← YOUR functional threshold power
 MAX_HEART_RATE=196               # ← YOUR max heart rate
 ```
 
-**Set FTP and MAX_HEART_RATE.** These numbers drive three things: the spike thresholds that decide what counts as a hard effort, the HUD's zone colors, and the power zones written into the Gemini prompt so the model knows whether 216W means "cruising" or "peak effort" for you.
+**Set FTP and MAX_HEART_RATE regardless of provider.** These numbers drive
+three things: the spike thresholds that decide what counts as a hard effort,
+the HUD's zone colors, and the power zones written into the vision prompt so
+the model knows whether 216W means "cruising" or "peak effort" for you.
 
 Verify it runs:
 
@@ -85,6 +90,53 @@ Verify it runs:
 ride-recap --help
 pytest                    # smoke tests, no video or API keys needed
 ```
+
+### Model providers
+
+Gemini remains the default. A complete run uses one provider for the vision
+scan, narrative selection, and prompt evaluation; caches and comparison
+reports are isolated by provider and model.
+
+For OpenAI:
+
+```env
+MODEL_PROVIDER=openai
+OPENAI_API_KEY=your-key-here
+OPENAI_MODEL=gpt-4.1-mini
+```
+
+For a local OpenAI-compatible VLM:
+
+```env
+MODEL_PROVIDER=local
+LOCAL_BASE_URL=http://127.0.0.1:8080/v1
+LOCAL_API_KEY=local
+LOCAL_MODEL=mlx-community/Qwen3-VL-8B-Instruct-3bit
+LOCAL_MAX_CONCURRENCY=1
+LOCAL_TIMEOUT_SECONDS=600
+```
+
+One way to serve that model on Apple Silicon is
+[`mlx-vlm`](https://github.com/Blaizzy/mlx-vlm):
+
+```bash
+python -m pip install -U mlx-vlm
+python -m mlx_vlm.server \
+  --model mlx-community/Qwen3-VL-8B-Instruct-3bit \
+  --host 127.0.0.1 \
+  --port 8080
+```
+
+Keep the server running and confirm it is ready before starting a scan:
+
+```bash
+curl http://127.0.0.1:8080/health
+curl http://127.0.0.1:8080/v1/models
+```
+
+The default local concurrency is deliberately one. The scanner evaluates
+multiple chapters and regions concurrently, while a single Apple Silicon VLM
+usually needs requests serialized to avoid memory pressure.
 
 ---
 
@@ -153,6 +205,9 @@ one issue #2 needs. Swap `clips` for `full` for the whole ride. The
 the download into a `data/raw/2026-07-10/` folder every command above runs
 against verbatim.
 
+See [the issue #2 model comparison](docs/model-comparison.md) for the
+Gemini, GPT-4.1 mini, and local Qwen3-VL results on these same eight chapters.
+
 ---
 
 ## Degrading gracefully
@@ -161,7 +216,7 @@ Only ffmpeg, a FIT file, and at least one `.MP4` are actually required. Everythi
 
 | Missing | What happens |
 |---|---|
-| `GEMINI_API_KEY` | Prints a warning, falls back to telemetry + Strava candidates and greedy selection. Runs, but this is the part that finds the good clips. |
+| Active provider credentials/server | Prints a warning or a clear connection error; without a working vision provider, candidates fall back to telemetry + Strava and greedy selection. |
 | Strava credentials | Only runs if you pass `--strava-activity` anyway. Warns and continues. |
 | Garmin credentials | Only needed for `garmin-download`. `process` never touches them. |
 | `OSM_CONTACT_EMAIL` | No GPS-derived place names; falls back to your `--origin`/`--road` flags or the design tokens. |
@@ -223,6 +278,7 @@ src/gopro_garmin_pipeline/
   fit_parser.py       # .fit → RideData (power, HR, speed, GPS)
   gpmf_sync.py        # GoPro GPS-time → FIT offset. The clock sync that matters.
   gemini_scan.py      # Two-pass vision scan (coarse regions → fine rubric)
+  models/             # Gemini, OpenAI, and local OpenAI-compatible adapters
   composer.py         # Candidate generation, fusion, selection, composition
   burn_overlay.py     # The 5-element HUD, landscape + portrait
   intro_outro.py      # Blur→title opener, outro recap card

--- a/docs/model-comparison.md
+++ b/docs/model-comparison.md
@@ -1,0 +1,88 @@
+# Vision-model comparison for issue #2
+
+This is a small, reproducible comparison of the unchanged `v10` vision rubric
+across three providers:
+
+- `gemini-3.5-flash`
+- `gpt-4.1-mini`
+- `mlx-community/Qwen3-VL-8B-Instruct-3bit`, served locally by MLX-VLM
+
+The test uses the eight video chapters in the `clips/` tier of the
+`iandmacomber/ride-recap-sample-2026-07-10` dataset. Those chapters contain all
+nine hand labels, including the five `must_include` moments. The hand labels
+are sparse and represent one rider's taste on one ride, so the numbers are a
+smell test rather than a benchmark.
+
+## Method
+
+Each provider ran the same two-pass scan and versioned prompts. Provider/model
+fingerprints isolate their caches. Comparisons were restricted to MP4 chapters
+present locally, so Gemini's cached ratings for the other eleven chapters did
+not inflate its model-only count.
+
+The comparison folds the five-dimension rubric onto the two hand-label axes:
+
+- `visual = mean(composition, scenery)`
+- `action = mean(motion, subject)`
+- `light` is excluded, matching the production selector
+
+A label and model rating count as a temporal match when their ride timestamps
+are within 15 seconds. Labels are injected blindly as forced fine-pass regions,
+so recall does not by itself measure discovery. Coarse-pass behavior and the
+semantic explanation must be interpreted alongside it.
+
+## Results
+
+| Model | Fine ratings | Temporal matches | Recall | Nominal precision | Visual SD (range) | Action SD (range) |
+|---|---:|---:|---:|---:|---:|---:|
+| Gemini 3.5 Flash | 24 | 8/9 | 89% | 33% | 1.68 (2.5-8.5) | 1.27 (2.5-7.5) |
+| GPT-4.1 mini | 23 | 8/9 | 89% | 35% | 1.13 (2.5-7.0) | 0.84 (2.5-5.5) |
+| Qwen3-VL 8B 3-bit | 28 | 9/9 | 100% | 32% | 1.28 (4.0-8.5) | 0.54 (4.0-6.0) |
+
+"Precision" is nominal: an unlabeled model rating is not necessarily a false
+positive because the human labels intentionally cover only nine moments.
+
+## Findings
+
+### Gemini has the strongest calibration
+
+Gemini produced the widest visual and action distributions. Its one reported
+miss, the George Washington Bridge label, is primarily a temporal-alignment
+artifact: it recognized the bridge in two nearby ratings, but both anchors
+fell just outside the 15-second matching window.
+
+### GPT finds most labeled moments but under-scores them
+
+GPT missed the labeled climb. On its eight temporal matches, its scores were
+lower than the hand labels by an average of 1.62 visual points and 2.00 action
+points. Matched ratings averaged 5.6 visual / 3.8 action, while model-only
+ratings averaged 5.5 / 3.9. That near-zero separation is the clearest sign that
+GPT flattens interesting and ordinary footage toward the middle.
+
+### Local Qwen understands fine clips but does not discover regions
+
+Qwen explicitly recognized the two-second deer and produced valid structured
+rubrics for every forced fine-pass region. However, every coarse pass returned
+zero hits. Its 28 ratings therefore came from hand-label timestamps, telemetry
+peaks, or periodic coverage samples rather than coarse visual discovery.
+
+Qwen also compressed action scores into the narrow range 4-6. It frequently
+over-rated ordinary wooded climbs and transitions, called the Hudson a lake,
+and described the 9W-sign moment without identifying the sign. Its 100% temporal
+recall should not be read as 100% semantic recognition or discovery recall.
+
+## Reproduction
+
+Select one provider at a time in `.env`, run the scan over the eight downloaded
+chapters, then compare without a manual offset:
+
+```bash
+MODEL_PROVIDER=gemini ride-recap compare data/raw/2026-07-10
+MODEL_PROVIDER=openai ride-recap compare data/raw/2026-07-10
+MODEL_PROVIDER=local ride-recap compare data/raw/2026-07-10
+```
+
+Reports use provider/model-specific filenames, and comparison only loads cache
+entries for MP4 chapters present in the ride directory. Raw footage, provider
+caches, `.env`, and generated reports under `data/raw/` are intentionally not
+committed.

--- a/docs/model-comparison.md
+++ b/docs/model-comparison.md
@@ -15,10 +15,11 @@ smell test rather than a benchmark.
 
 ## Method
 
-Each provider ran the same two-pass scan and versioned prompts. Provider/model
-fingerprints isolate their caches. Comparisons were restricted to MP4 chapters
-present locally, so Gemini's cached ratings for the other eleven chapters did
-not inflate its model-only count.
+Each provider ran the same two-pass scan and versioned prompts. Provider cache
+directories are isolated, and non-Gemini cache filenames include a model
+fingerprint. Comparisons were restricted to the eight labeled chapters, so
+Gemini's cached ratings for the other eleven chapters did not inflate its
+model-only count. Gemini retains legacy cache filenames for compatibility.
 
 The comparison folds the five-dimension rubric onto the two hand-label axes:
 
@@ -73,16 +74,19 @@ recall should not be read as 100% semantic recognition or discovery recall.
 
 ## Reproduction
 
-Select one provider at a time in `.env`, run the scan over the eight downloaded
-chapters, then compare without a manual offset:
+The exact caches and reports behind the table are committed under
+`samples/2026-07-10/`. Reproduce each report without video, credentials, or a
+running local model:
 
 ```bash
-MODEL_PROVIDER=gemini ride-recap compare data/raw/2026-07-10
-MODEL_PROVIDER=openai ride-recap compare data/raw/2026-07-10
-MODEL_PROVIDER=local ride-recap compare data/raw/2026-07-10
+MODEL_PROVIDER=gemini ride-recap compare samples/2026-07-10
+MODEL_PROVIDER=openai OPENAI_MODEL=gpt-4.1-mini \
+  ride-recap compare samples/2026-07-10
+MODEL_PROVIDER=local LOCAL_MODEL=mlx-community/Qwen3-VL-8B-Instruct-3bit \
+  ride-recap compare samples/2026-07-10
 ```
 
-Reports use provider/model-specific filenames, and comparison only loads cache
-entries for MP4 chapters present in the ride directory. Raw footage, provider
-caches, `.env`, and generated reports under `data/raw/` are intentionally not
-committed.
+Reports use provider/model-specific filenames. With downloaded footage,
+comparison uses the MP4 chapters present in the ride directory; in the
+video-free committed sample, the labeled chapter names define the same tier.
+Raw footage, `.env`, and working outputs under `data/raw/` remain ignored.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dependencies = [
     "click>=8.1.0",
     "pydantic-settings>=2.0",
     "google-genai>=1.0",
+    # >=1.66 ships client.responses.parse (Responses API + Structured Outputs).
+    # 1.40 has no Responses resource — do not lower this floor.
+    "openai>=1.66.0",
     "garminconnect>=0.3.0",
     "flask>=3.0",
     "streamlit>=1.35.0",

--- a/samples/2026-07-10/.gemini_cache/GX010333_v10_l1195d698.json
+++ b/samples/2026-07-10/.gemini_cache/GX010333_v10_l1195d698.json
@@ -15,7 +15,8 @@
     "raw_sum": 30,
     "clip_type": "urban",
     "crop_x": 50,
-    "reason": "Golden hour cruise along NYC's West Side path past modern skyline"
+    "reason": "Golden hour cruise along NYC's West Side path past modern skyline",
+    "ride_time_secs": 342.4
   },
   {
     "clip_name": "GX010333.MP4",
@@ -33,6 +34,7 @@
     "raw_sum": 14,
     "clip_type": "transition",
     "crop_x": 50,
-    "reason": "Entering a dark underpass under the West Side Highway deck."
+    "reason": "Entering a dark underpass under the West Side Highway deck.",
+    "ride_time_secs": 357.0
   }
 ]

--- a/samples/2026-07-10/.gemini_cache/GX010336_v10_l4d10d929.json
+++ b/samples/2026-07-10/.gemini_cache/GX010336_v10_l4d10d929.json
@@ -15,7 +15,8 @@
     "raw_sum": 32,
     "clip_type": "landmark",
     "crop_x": 50,
-    "reason": "George Washington Bridge comes into view under soft morning light."
+    "reason": "George Washington Bridge comes into view under soft morning light.",
+    "ride_time_secs": 1513.8
   },
   {
     "clip_name": "GX010336.MP4",
@@ -33,6 +34,7 @@
     "raw_sum": 32,
     "clip_type": "urban",
     "crop_x": 50,
-    "reason": "Passing close to MTA city buses on an urban bridge approach."
+    "reason": "Passing close to MTA city buses on an urban bridge approach.",
+    "ride_time_secs": 1552.0
   }
 ]

--- a/samples/2026-07-10/.gemini_cache/GX010338_v10_lbddf7158.json
+++ b/samples/2026-07-10/.gemini_cache/GX010338_v10_lbddf7158.json
@@ -15,7 +15,8 @@
     "raw_sum": 29,
     "clip_type": "descent",
     "crop_x": 50,
-    "reason": "Sun-drenched solo descent down the tree-lined Palisades cliffside road."
+    "reason": "Sun-drenched solo descent down the tree-lined Palisades cliffside road.",
+    "ride_time_secs": 2537.0
   },
   {
     "clip_name": "GX010338.MP4",
@@ -33,7 +34,8 @@
     "raw_sum": 36,
     "clip_type": "landmark",
     "crop_x": 50,
-    "reason": "Iconic George Washington Bridge reveal climbing up tree-lined River Road."
+    "reason": "Iconic George Washington Bridge reveal climbing up tree-lined River Road.",
+    "ride_time_secs": 2574.0
   },
   {
     "clip_name": "GX010338.MP4",
@@ -51,7 +53,8 @@
     "raw_sum": 37,
     "clip_type": "landmark",
     "crop_x": 50,
-    "reason": "Cruising under the massive George Washington Bridge with golden hour flare."
+    "reason": "Cruising under the massive George Washington Bridge with golden hour flare.",
+    "ride_time_secs": 2614.5
   },
   {
     "clip_name": "GX010338.MP4",
@@ -69,7 +72,8 @@
     "raw_sum": 27,
     "clip_type": "scenery",
     "crop_x": 50,
-    "reason": "Scenic morning cruise along the tree-lined Palisades cliffs with beautiful dappled light."
+    "reason": "Scenic morning cruise along the tree-lined Palisades cliffs with beautiful dappled light.",
+    "ride_time_secs": 2641.0
   },
   {
     "clip_name": "GX010338.MP4",
@@ -87,7 +91,8 @@
     "raw_sum": 30,
     "clip_type": "scenery",
     "crop_x": 50,
-    "reason": "Scenic morning climb past the dramatic Palisades cliffs on River Road."
+    "reason": "Scenic morning climb past the dramatic Palisades cliffs on River Road.",
+    "ride_time_secs": 2674.0
   },
   {
     "clip_name": "GX010338.MP4",
@@ -105,6 +110,7 @@
     "raw_sum": 22,
     "clip_type": "transition",
     "crop_x": 50,
-    "reason": "Cruising through dappled morning light on a quiet, wooded park road."
+    "reason": "Cruising through dappled morning light on a quiet, wooded park road.",
+    "ride_time_secs": 2719.0
   }
 ]

--- a/samples/2026-07-10/.gemini_cache/GX010339_v10_l5771ba36.json
+++ b/samples/2026-07-10/.gemini_cache/GX010339_v10_l5771ba36.json
@@ -15,7 +15,8 @@
     "raw_sum": 37,
     "clip_type": "descent",
     "crop_x": 50,
-    "reason": "Fast River Road descent opening to beautiful Hudson River views."
+    "reason": "Fast River Road descent opening to beautiful Hudson River views.",
+    "ride_time_secs": 2911.5
   },
   {
     "clip_name": "GX010339.MP4",
@@ -33,7 +34,8 @@
     "raw_sum": 30,
     "clip_type": "climb",
     "crop_x": 50,
-    "reason": "Climbing the historic brick road of Fort Tryon Park under dappled sunlight."
+    "reason": "Climbing the historic brick road of Fort Tryon Park under dappled sunlight.",
+    "ride_time_secs": 3012.0
   },
   {
     "clip_name": "GX010339.MP4",
@@ -51,6 +53,7 @@
     "raw_sum": 33,
     "clip_type": "descent",
     "crop_x": 50,
-    "reason": "Dynamic high-speed descent down River Road with beautiful dappled morning light."
+    "reason": "Dynamic high-speed descent down River Road with beautiful dappled morning light.",
+    "ride_time_secs": 3142.0
   }
 ]

--- a/samples/2026-07-10/.gemini_cache/GX010344_v10_ld5c27360.json
+++ b/samples/2026-07-10/.gemini_cache/GX010344_v10_ld5c27360.json
@@ -15,7 +15,8 @@
     "raw_sum": 28,
     "clip_type": "incident",
     "crop_x": 50,
-    "reason": "Steep climb with a close encounter passing a deer roadside."
+    "reason": "Steep climb with a close encounter passing a deer roadside.",
+    "ride_time_secs": 6347.8
   },
   {
     "clip_name": "GX010344.MP4",
@@ -33,7 +34,8 @@
     "raw_sum": 21,
     "clip_type": "climb",
     "crop_x": 50,
-    "reason": "Anaerobic climb up steep, cracked road with sun filtering through trees"
+    "reason": "Anaerobic climb up steep, cracked road with sun filtering through trees",
+    "ride_time_secs": 6361.0
   },
   {
     "clip_name": "GX010344.MP4",
@@ -51,7 +53,8 @@
     "raw_sum": 23,
     "clip_type": "climb",
     "crop_x": 50,
-    "reason": "Steep climb up River Road past Palisades rock faces at threshold effort."
+    "reason": "Steep climb up River Road past Palisades rock faces at threshold effort.",
+    "ride_time_secs": 6410.0
   },
   {
     "clip_name": "GX010344.MP4",
@@ -69,7 +72,8 @@
     "raw_sum": 23,
     "clip_type": "climb",
     "crop_x": 50,
-    "reason": "High-power anaerobic climb up a rugged, tree-lined historic road."
+    "reason": "High-power anaerobic climb up a rugged, tree-lined historic road.",
+    "ride_time_secs": 6425.0
   },
   {
     "clip_name": "GX010344.MP4",
@@ -87,7 +91,8 @@
     "raw_sum": 22,
     "clip_type": "climb",
     "crop_x": 50,
-    "reason": "Steep anaerobic climb up a quiet, tree-framed road with stone walls."
+    "reason": "Steep anaerobic climb up a quiet, tree-framed road with stone walls.",
+    "ride_time_secs": 6450.3
   },
   {
     "clip_name": "GX010344.MP4",
@@ -105,7 +110,8 @@
     "raw_sum": 19,
     "clip_type": "climb",
     "crop_x": 50,
-    "reason": "Solo climb up a quiet, tree-shaded hill at high power."
+    "reason": "Solo climb up a quiet, tree-shaded hill at high power.",
+    "ride_time_secs": 6470.0
   },
   {
     "clip_name": "GX010344.MP4",
@@ -123,6 +129,7 @@
     "raw_sum": 18,
     "clip_type": "transition",
     "crop_x": 50,
-    "reason": "Unremarkable transit footage on a generic park access road."
+    "reason": "Unremarkable transit footage on a generic park access road.",
+    "ride_time_secs": 6521.5
   }
 ]

--- a/samples/2026-07-10/.gemini_cache/GX010346_v10_l356a192b.json
+++ b/samples/2026-07-10/.gemini_cache/GX010346_v10_l356a192b.json
@@ -15,6 +15,7 @@
     "raw_sum": 34,
     "clip_type": "landmark",
     "crop_x": 50,
-    "reason": "Cruising toward the iconic George Washington Bridge tower on a sunny day."
+    "reason": "Cruising toward the iconic George Washington Bridge tower on a sunny day.",
+    "ride_time_secs": 9203.5
   }
 ]

--- a/samples/2026-07-10/.gemini_cache/GX010350_v10_l8a3cac98.json
+++ b/samples/2026-07-10/.gemini_cache/GX010350_v10_l8a3cac98.json
@@ -15,7 +15,8 @@
     "raw_sum": 29,
     "clip_type": "urban",
     "crop_x": 50,
-    "reason": "Cruising past towering Hudson Yards skyscrapers under bright New York skies."
+    "reason": "Cruising past towering Hudson Yards skyscrapers under bright New York skies.",
+    "ride_time_secs": 11253.5
   },
   {
     "clip_name": "GX010350.MP4",
@@ -33,6 +34,7 @@
     "raw_sum": 25,
     "clip_type": "urban",
     "crop_x": 50,
-    "reason": "Cruising past modern skyscrapers of Hudson Yards and the High Line."
+    "reason": "Cruising past modern skyscrapers of Hudson Yards and the High Line.",
+    "ride_time_secs": 11308.0
   }
 ]

--- a/samples/2026-07-10/.local_cache/GX010333_v10_m61708849_l7219e20b.json
+++ b/samples/2026-07-10/.local_cache/GX010333_v10_m61708849_l7219e20b.json
@@ -1,0 +1,59 @@
+[
+  {
+    "clip_name": "GX010333.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 5.5,
+    "peak_offset": 0.55,
+    "rubric": {
+      "light": 6,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 6
+    },
+    "raw_sum": 31,
+    "clip_type": "scenery",
+    "crop_x": 50,
+    "reason": "Early evening ride through urban park with emerging skyline",
+    "ride_time_secs": 327.5
+  },
+  {
+    "clip_name": "GX010333.MP4",
+    "video_start": 24.0,
+    "video_end": 34.0,
+    "anchor_video_secs": 29.5,
+    "peak_offset": 0.55,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 6
+    },
+    "raw_sum": 31,
+    "clip_type": "urban",
+    "crop_x": 50,
+    "reason": "Cruising under city overpass at golden hour, rider visible",
+    "ride_time_secs": 351.5
+  },
+  {
+    "clip_name": "GX010333.MP4",
+    "video_start": 45.0,
+    "video_end": 55.0,
+    "anchor_video_secs": 50.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 3,
+      "subject": 4
+    },
+    "raw_sum": 21,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Underpass transition with construction barriers visible",
+    "ride_time_secs": 372.0
+  }
+]

--- a/samples/2026-07-10/.local_cache/GX010336_v10_m61708849_labeba3a3.json
+++ b/samples/2026-07-10/.local_cache/GX010336_v10_m61708849_labeba3a3.json
@@ -1,0 +1,59 @@
+[
+  {
+    "clip_name": "GX010336.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 5.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 22,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Early morning transit through urban park path",
+    "ride_time_secs": 1503.0
+  },
+  {
+    "clip_name": "GX010336.MP4",
+    "video_start": 18.0,
+    "video_end": 28.0,
+    "anchor_video_secs": 23.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 6,
+      "subject": 4
+    },
+    "raw_sum": 24,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Cruising toward bridge at golden hour, motion blur on road",
+    "ride_time_secs": 1521.0
+  },
+  {
+    "clip_name": "GX010336.MP4",
+    "video_start": 45.0,
+    "video_end": 55.0,
+    "anchor_video_secs": 50.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 6,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 24,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Steady pace under early evening sky, rider centered on road",
+    "ride_time_secs": 1548.0
+  }
+]

--- a/samples/2026-07-10/.local_cache/GX010338_v10_m61708849_l9ffb05f5.json
+++ b/samples/2026-07-10/.local_cache/GX010338_v10_m61708849_l9ffb05f5.json
@@ -1,0 +1,97 @@
+[
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 5.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 26,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Rising gradient with early morning sun, rider climbing steadily",
+    "ride_time_secs": 2536.0
+  },
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 45.0,
+    "video_end": 65.0,
+    "anchor_video_secs": 60.0,
+    "peak_offset": 0.75,
+    "rubric": {
+      "light": 6,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 6
+    },
+    "raw_sum": 31,
+    "clip_type": "scenery",
+    "crop_x": 50,
+    "reason": "Emerging from trees into skyline reveal, mid-clip",
+    "ride_time_secs": 2591.0
+  },
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 90.0,
+    "video_end": 100.0,
+    "anchor_video_secs": 95.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 6,
+      "subject": 4
+    },
+    "raw_sum": 29,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Early-morning climb through wooded path, rider cruising",
+    "ride_time_secs": 2626.0
+  },
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 135.0,
+    "video_end": 145.0,
+    "anchor_video_secs": 140.5,
+    "peak_offset": 0.55,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 5
+    },
+    "raw_sum": 31,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Cruising up a gentle climb, trees and rock walls frame the road",
+    "ride_time_secs": 2671.5
+  },
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 180.0,
+    "video_end": 190.0,
+    "anchor_video_secs": 185.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 8,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 4
+    },
+    "raw_sum": 31,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Cruising uphill through lush forest, rider centered, clear path ahead",
+    "ride_time_secs": 2716.0
+  }
+]

--- a/samples/2026-07-10/.local_cache/GX010339_v10_m61708849_lf965738a.json
+++ b/samples/2026-07-10/.local_cache/GX010339_v10_m61708849_lf965738a.json
@@ -1,0 +1,154 @@
+[
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 5.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 8,
+      "motion": 6,
+      "scenery": 7,
+      "subject": 5
+    },
+    "raw_sum": 33,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Rising sun through trees on a gentle climb",
+    "ride_time_secs": 2894.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 19.0,
+    "video_end": 29.0,
+    "anchor_video_secs": 24.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 8,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 4
+    },
+    "raw_sum": 31,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Sunlit trail with lake view, rider cruising at 31mph",
+    "ride_time_secs": 2913.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 45.0,
+    "video_end": 55.0,
+    "anchor_video_secs": 50.5,
+    "peak_offset": 0.55,
+    "rubric": {
+      "light": 7,
+      "composition": 8,
+      "motion": 5,
+      "scenery": 6,
+      "subject": 4
+    },
+    "raw_sum": 30,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Climbing uphill through green forest, rider visible",
+    "ride_time_secs": 2939.5
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 90.0,
+    "video_end": 100.0,
+    "anchor_video_secs": 95.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 6,
+      "motion": 4,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 22,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Cruising under shaded canopy, no landmark or drama",
+    "ride_time_secs": 2984.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 135.0,
+    "video_end": 145.0,
+    "anchor_video_secs": 140.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 6,
+      "motion": 4,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 22,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Cruising uphill, rider barely visible behind foliage",
+    "ride_time_secs": 3029.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 180.0,
+    "video_end": 190.0,
+    "anchor_video_secs": 185.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 6,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 6,
+      "subject": 5
+    },
+    "raw_sum": 29,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Climbing a tree-lined hillside road, rider at 246W",
+    "ride_time_secs": 3074.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 225.0,
+    "video_end": 235.0,
+    "anchor_video_secs": 230.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 23,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Cruising through shaded forest with dappled light",
+    "ride_time_secs": 3119.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 246.001,
+    "video_end": 256.001,
+    "anchor_video_secs": 251.00099999999998,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 6,
+      "subject": 4
+    },
+    "raw_sum": 29,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Cruising through shaded forest with dappled light, rider centered",
+    "ride_time_secs": 3140.0
+  }
+]

--- a/samples/2026-07-10/.local_cache/GX010341_v10_m61708849_lac3478d6.json
+++ b/samples/2026-07-10/.local_cache/GX010341_v10_m61708849_lac3478d6.json
@@ -6,16 +6,16 @@
     "anchor_video_secs": 5.0,
     "peak_offset": 0.5,
     "rubric": {
-      "light": 4,
-      "composition": 3,
-      "motion": 3,
+      "light": 7,
+      "composition": 7,
+      "motion": 5,
       "scenery": 4,
-      "subject": 2
+      "subject": 4
     },
-    "raw_sum": 16,
+    "raw_sum": 27,
     "clip_type": "transition",
     "crop_x": 50,
-    "reason": "Unremarkable transit footage on a flat, empty road bordered by trees.",
+    "reason": "Cruising through shaded forest road, clear path ahead",
     "ride_time_secs": 4921.0
   }
 ]

--- a/samples/2026-07-10/.local_cache/GX010344_v10_m61708849_l226913ed.json
+++ b/samples/2026-07-10/.local_cache/GX010344_v10_m61708849_l226913ed.json
@@ -1,0 +1,97 @@
+[
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 0,
+    "video_end": 7.0,
+    "anchor_video_secs": 3.5,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 4,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 21,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Deer pauses on trail, rider cruising through forest",
+    "ride_time_secs": 6348.5
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 48.0,
+    "video_end": 58.0,
+    "anchor_video_secs": 53.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 4,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 25,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Climbing uphill through wooded trail, rider visible at peak",
+    "ride_time_secs": 6398.0
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 90.0,
+    "video_end": 106.101,
+    "anchor_video_secs": 98.85555,
+    "peak_offset": 0.55,
+    "rubric": {
+      "light": 4,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 22,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Cruising up a forested climb, rider visible only at frame 3",
+    "ride_time_secs": 6443.9
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 135.0,
+    "video_end": 145.0,
+    "anchor_video_secs": 140.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 26,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Calm suburban ride, rider cruising through shaded trees",
+    "ride_time_secs": 6485.0
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 180.0,
+    "video_end": 190.0,
+    "anchor_video_secs": 185.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 6,
+      "composition": 5,
+      "motion": 4,
+      "scenery": 4,
+      "subject": 4
+    },
+    "raw_sum": 23,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Cruising through quiet residential streets, uneventful but steady motion.",
+    "ride_time_secs": 6530.0
+  }
+]

--- a/samples/2026-07-10/.local_cache/GX010346_v10_m61708849_l356a192b.json
+++ b/samples/2026-07-10/.local_cache/GX010346_v10_m61708849_l356a192b.json
@@ -1,0 +1,21 @@
+[
+  {
+    "clip_name": "GX010346.MP4",
+    "video_start": 0,
+    "video_end": 6.0,
+    "anchor_video_secs": 4.5,
+    "peak_offset": 0.75,
+    "rubric": {
+      "light": 7,
+      "composition": 8,
+      "motion": 5,
+      "scenery": 9,
+      "subject": 7
+    },
+    "raw_sum": 36,
+    "clip_type": "landmark",
+    "crop_x": 50,
+    "reason": "Emerging from underbridge into skyline reveal",
+    "ride_time_secs": 9205.5
+  }
+]

--- a/samples/2026-07-10/.local_cache/GX010350_v10_m61708849_l02b7c14a.json
+++ b/samples/2026-07-10/.local_cache/GX010350_v10_m61708849_l02b7c14a.json
@@ -1,0 +1,40 @@
+[
+  {
+    "clip_name": "GX010350.MP4",
+    "video_start": 0,
+    "video_end": 7.0,
+    "anchor_video_secs": 3.8500000000000005,
+    "peak_offset": 0.55,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 8,
+      "subject": 6
+    },
+    "raw_sum": 33,
+    "clip_type": "scenery",
+    "crop_x": 50,
+    "reason": "Golden-hour skyline reveal under clear sky, urban grandeur",
+    "ride_time_secs": 11254.9
+  },
+  {
+    "clip_name": "GX010350.MP4",
+    "video_start": 45.0,
+    "video_end": 55.0,
+    "anchor_video_secs": 50.5,
+    "peak_offset": 0.55,
+    "rubric": {
+      "light": 6,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 8,
+      "subject": 6
+    },
+    "raw_sum": 32,
+    "clip_type": "scenery",
+    "crop_x": 50,
+    "reason": "Golden-hour skyline reveal with urban motion blur",
+    "ride_time_secs": 11301.5
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010333_v10_m57ca8f7b_l7219e20b.json
+++ b/samples/2026-07-10/.openai_cache/GX010333_v10_m57ca8f7b_l7219e20b.json
@@ -1,0 +1,40 @@
+[
+  {
+    "clip_name": "GX010333.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 7.0,
+    "peak_offset": 0.7,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 3
+    },
+    "raw_sum": 28,
+    "clip_type": "urban",
+    "crop_x": 50,
+    "reason": "Pleasant early evening light with urban park and city buildings",
+    "ride_time_secs": 329.0
+  },
+  {
+    "clip_name": "GX010333.MP4",
+    "video_start": 25.0,
+    "video_end": 55.0,
+    "anchor_video_secs": 29.5,
+    "peak_offset": 0.15,
+    "rubric": {
+      "light": 5,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 3,
+      "subject": 2
+    },
+    "raw_sum": 20,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Ride enters and continues under an urban overpass, enclosed space lowers scenery",
+    "ride_time_secs": 351.5
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010336_v10_m57ca8f7b_labeba3a3.json
+++ b/samples/2026-07-10/.openai_cache/GX010336_v10_m57ca8f7b_labeba3a3.json
@@ -1,0 +1,59 @@
+[
+  {
+    "clip_name": "GX010336.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 8.0,
+    "peak_offset": 0.8,
+    "rubric": {
+      "light": 4,
+      "composition": 4,
+      "motion": 4,
+      "scenery": 4,
+      "subject": 1
+    },
+    "raw_sum": 17,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Cruising downhill on an ordinary urban street with sunset sky",
+    "ride_time_secs": 1506.0
+  },
+  {
+    "clip_name": "GX010336.MP4",
+    "video_start": 15.0,
+    "video_end": 25.0,
+    "anchor_video_secs": 20.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 4,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 4,
+      "subject": 2
+    },
+    "raw_sum": 20,
+    "clip_type": "urban",
+    "crop_x": 50,
+    "reason": "Open urban road with distant bridge, moderate speed cruising",
+    "ride_time_secs": 1518.0
+  },
+  {
+    "clip_name": "GX010336.MP4",
+    "video_start": 45.0,
+    "video_end": 55.0,
+    "anchor_video_secs": 48.0,
+    "peak_offset": 0.3,
+    "rubric": {
+      "light": 4,
+      "composition": 3,
+      "motion": 3,
+      "scenery": 2,
+      "subject": 2
+    },
+    "raw_sum": 14,
+    "clip_type": "transition",
+    "crop_x": 50,
+    "reason": "Stuck behind a bus on flat road, slow motion, limited subject",
+    "ride_time_secs": 1546.0
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010338_v10_m57ca8f7b_l9ffb05f5.json
+++ b/samples/2026-07-10/.openai_cache/GX010338_v10_m57ca8f7b_l9ffb05f5.json
@@ -1,0 +1,78 @@
+[
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 0,
+    "video_end": 105.0,
+    "anchor_video_secs": 73.5,
+    "peak_offset": 0.7,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 6,
+      "subject": 3
+    },
+    "raw_sum": 27,
+    "clip_type": "descent",
+    "crop_x": 50,
+    "reason": "Descent with greenery and bridge glimpse, moderate speed, low power",
+    "ride_time_secs": 2604.5
+  },
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 115.0,
+    "video_end": 145.0,
+    "anchor_video_secs": 139.0,
+    "peak_offset": 0.8,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 3
+    },
+    "raw_sum": 29,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Climbing a leafy road with dappled sunlight, moderate motion",
+    "ride_time_secs": 2670.0
+  },
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 155.0,
+    "video_end": 175.0,
+    "anchor_video_secs": 162.0,
+    "peak_offset": 0.35,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 2
+    },
+    "raw_sum": 27,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Golden hour light on leafy climb, moderate motion, no clear subject",
+    "ride_time_secs": 2693.0
+  },
+  {
+    "clip_name": "GX010338.MP4",
+    "video_start": 180.0,
+    "video_end": 190.0,
+    "anchor_video_secs": 185.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 4,
+      "scenery": 6,
+      "subject": 3
+    },
+    "raw_sum": 26,
+    "clip_type": "descent",
+    "crop_x": 50,
+    "reason": "Nice light and greenery, gentle downhill cruise, no clear subject",
+    "ride_time_secs": 2716.0
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010339_v10_m57ca8f7b_lf965738a.json
+++ b/samples/2026-07-10/.openai_cache/GX010339_v10_m57ca8f7b_lf965738a.json
@@ -1,0 +1,97 @@
+[
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 5.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 6,
+      "scenery": 5,
+      "subject": 3
+    },
+    "raw_sum": 28,
+    "clip_type": "descent",
+    "crop_x": 50,
+    "reason": "Descending shaded tree-lined road with nice light but no clear riders",
+    "ride_time_secs": 2894.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 19.0,
+    "video_end": 29.0,
+    "anchor_video_secs": 22.5,
+    "peak_offset": 0.35,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 7,
+      "scenery": 7,
+      "subject": 2
+    },
+    "raw_sum": 30,
+    "clip_type": "descent",
+    "crop_x": 50,
+    "reason": "Sunny fast descent past river with open roadway and greenery",
+    "ride_time_secs": 2911.5
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 35.0,
+    "video_end": 195.0,
+    "anchor_video_secs": 147.0,
+    "peak_offset": 0.7,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 6,
+      "scenery": 7,
+      "subject": 5
+    },
+    "raw_sum": 31,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Sunlight dappled climb on stone path, steady moderate effort",
+    "ride_time_secs": 3036.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 225.0,
+    "video_end": 235.0,
+    "anchor_video_secs": 232.0,
+    "peak_offset": 0.7,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 7,
+      "scenery": 6,
+      "subject": 4
+    },
+    "raw_sum": 30,
+    "clip_type": "descent",
+    "crop_x": 50,
+    "reason": "Speedy descent through dappled woodland light, nice motion and setting",
+    "ride_time_secs": 3121.0
+  },
+  {
+    "clip_name": "GX010339.MP4",
+    "video_start": 245.0,
+    "video_end": 255.0,
+    "anchor_video_secs": 248.0,
+    "peak_offset": 0.3,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 7,
+      "scenery": 7,
+      "subject": 2
+    },
+    "raw_sum": 29,
+    "clip_type": "descent",
+    "crop_x": 50,
+    "reason": "Fast descent with sun filtering through trees, no clear subject",
+    "ride_time_secs": 3137.0
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010341_v10_m57ca8f7b_lac3478d6.json
+++ b/samples/2026-07-10/.openai_cache/GX010341_v10_m57ca8f7b_lac3478d6.json
@@ -1,0 +1,40 @@
+[
+  {
+    "clip_name": "GX010341.MP4",
+    "video_start": 0,
+    "video_end": 10.0,
+    "anchor_video_secs": 5.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 4,
+      "scenery": 7,
+      "subject": 2
+    },
+    "raw_sum": 26,
+    "clip_type": "scenery",
+    "crop_x": 50,
+    "reason": "Pleasant quiet road with dappled light but minimal action",
+    "ride_time_secs": 4921.0
+  },
+  {
+    "clip_name": "GX010341.MP4",
+    "video_start": 15.0,
+    "video_end": 25.0,
+    "anchor_video_secs": 20.0,
+    "peak_offset": 0.5,
+    "rubric": {
+      "light": 7,
+      "composition": 5,
+      "motion": 5,
+      "scenery": 5,
+      "subject": 3
+    },
+    "raw_sum": 25,
+    "clip_type": "urban",
+    "crop_x": 50,
+    "reason": "Calm ride on tree-lined street, steady pace with good light",
+    "ride_time_secs": 4936.0
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010344_v10_m57ca8f7b_l226913ed.json
+++ b/samples/2026-07-10/.openai_cache/GX010344_v10_m57ca8f7b_l226913ed.json
@@ -1,0 +1,97 @@
+[
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 0,
+    "video_end": 7.0,
+    "anchor_video_secs": 2.1,
+    "peak_offset": 0.3,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 3,
+      "scenery": 7,
+      "subject": 4
+    },
+    "raw_sum": 27,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Morning light on climb with visible deer and strong gradient",
+    "ride_time_secs": 6347.1
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 15.0,
+    "video_end": 25.0,
+    "anchor_video_secs": 21.0,
+    "peak_offset": 0.6,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 5
+    },
+    "raw_sum": 30,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Bright tree-lined steep climb with strong power output",
+    "ride_time_secs": 6366.0
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 35.0,
+    "video_end": 125.0,
+    "anchor_video_secs": 116.0,
+    "peak_offset": 0.9,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 4
+    },
+    "raw_sum": 29,
+    "clip_type": "climb",
+    "crop_x": 50,
+    "reason": "Bright shaded climb with strong power, moderate motion",
+    "ride_time_secs": 6461.0
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 135.0,
+    "video_end": 145.0,
+    "anchor_video_secs": 141.0,
+    "peak_offset": 0.6,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 4,
+      "scenery": 7,
+      "subject": 2
+    },
+    "raw_sum": 26,
+    "clip_type": "urban",
+    "crop_x": 50,
+    "reason": "Quiet early morning climb in dappled shade, pleasant trees and houses",
+    "ride_time_secs": 6486.0
+  },
+  {
+    "clip_name": "GX010344.MP4",
+    "video_start": 180.0,
+    "video_end": 190.0,
+    "anchor_video_secs": 183.0,
+    "peak_offset": 0.3,
+    "rubric": {
+      "light": 7,
+      "composition": 5,
+      "motion": 4,
+      "scenery": 4,
+      "subject": 2
+    },
+    "raw_sum": 22,
+    "clip_type": "descent",
+    "crop_x": 50,
+    "reason": "Sunny descent with mild speed and shadows, no clear subject",
+    "ride_time_secs": 6528.0
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010346_v10_m57ca8f7b_l356a192b.json
+++ b/samples/2026-07-10/.openai_cache/GX010346_v10_m57ca8f7b_l356a192b.json
@@ -1,0 +1,21 @@
+[
+  {
+    "clip_name": "GX010346.MP4",
+    "video_start": 0,
+    "video_end": 5.0,
+    "anchor_video_secs": 1.0,
+    "peak_offset": 0.2,
+    "rubric": {
+      "light": 7,
+      "composition": 7,
+      "motion": 4,
+      "scenery": 4,
+      "subject": 2
+    },
+    "raw_sum": 24,
+    "clip_type": "urban",
+    "crop_x": 50,
+    "reason": "Bridge walkway with bright light but low motion and weak subject",
+    "ride_time_secs": 9202.0
+  }
+]

--- a/samples/2026-07-10/.openai_cache/GX010350_v10_m57ca8f7b_l02b7c14a.json
+++ b/samples/2026-07-10/.openai_cache/GX010350_v10_m57ca8f7b_l02b7c14a.json
@@ -1,0 +1,21 @@
+[
+  {
+    "clip_name": "GX010350.MP4",
+    "video_start": 0,
+    "video_end": 55.0,
+    "anchor_video_secs": 16.5,
+    "peak_offset": 0.3,
+    "rubric": {
+      "light": 7,
+      "composition": 6,
+      "motion": 5,
+      "scenery": 7,
+      "subject": 4
+    },
+    "raw_sum": 29,
+    "clip_type": "urban",
+    "crop_x": 50,
+    "reason": "Bright city street with strong architectural lines, moderate motion",
+    "ride_time_secs": 11267.5
+  }
+]

--- a/samples/2026-07-10/prompt_eval_gemini_gemini-3.5-flash.json
+++ b/samples/2026-07-10/prompt_eval_gemini_gemini-3.5-flash.json
@@ -1,0 +1,359 @@
+{
+  "date_folder": "samples/2026-07-10",
+  "summary": {
+    "provider": "gemini",
+    "model": "gemini-3.5-flash",
+    "n_labels": 9,
+    "n_model_hits": 24,
+    "n_matched": 8,
+    "n_label_only": 1,
+    "n_model_only": 16,
+    "precision": 0.333,
+    "recall": 0.889
+  },
+  "patterns": {
+    "model_misses_by_type": {
+      "scenery": 1
+    },
+    "model_overflag_by_clip_type": {
+      "urban": 3,
+      "descent": 2,
+      "landmark": 2,
+      "scenery": 2,
+      "transition": 2,
+      "climb": 5
+    },
+    "score_agreement": {
+      "n": 8,
+      "visual_mean_diff": -1.12,
+      "action_mean_diff": -1.25
+    },
+    "type_agreement": {
+      "matching": 2,
+      "total": 8,
+      "rate": 0.25
+    },
+    "avg_matched_scores": {
+      "visual": 6.2,
+      "action": 4.9
+    },
+    "avg_model_only_scores": {
+      "visual": 5.8,
+      "action": 4.4
+    },
+    "min_matched_max_score": 3
+  },
+  "matched": [
+    {
+      "ride_time_secs": 351,
+      "ride_time_str": "5:51",
+      "source": "both",
+      "clip_name": "GX010333.MP4",
+      "video_secs": 29.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "pretty flowers",
+      "model_visual": 2,
+      "model_action": 3,
+      "model_clip_type": "transition",
+      "model_reason": "Entering a dark underpass under the West Side Highway deck."
+    },
+    {
+      "ride_time_secs": 1521,
+      "ride_time_str": "25:21",
+      "source": "both",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 23.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "pretty view",
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "landmark",
+      "model_reason": "George Washington Bridge comes into view under soft morning light."
+    },
+    {
+      "ride_time_secs": 2913,
+      "ride_time_str": "48:33",
+      "source": "both",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 24.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 8,
+      "label_notes": "hudson with speed",
+      "model_visual": 8,
+      "model_action": 8,
+      "model_clip_type": "descent",
+      "model_reason": "Fast River Road descent opening to beautiful Hudson River views."
+    },
+    {
+      "ride_time_secs": 4921,
+      "ride_time_str": "1:22:01",
+      "source": "both",
+      "clip_name": "GX010341.MP4",
+      "video_secs": 5.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "9W sign",
+      "model_visual": 4,
+      "model_action": 2,
+      "model_clip_type": "transition",
+      "model_reason": "Unremarkable transit footage on a flat, empty road bordered by trees."
+    },
+    {
+      "ride_time_secs": 6347,
+      "ride_time_str": "1:45:47",
+      "source": "both",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 2.0,
+      "label_type": "action",
+      "label_visual": 7,
+      "label_action": 8,
+      "label_notes": "Deer!",
+      "model_visual": 6,
+      "model_action": 6,
+      "model_clip_type": "incident",
+      "model_reason": "Steep climb with a close encounter passing a deer roadside."
+    },
+    {
+      "ride_time_secs": 6398,
+      "ride_time_str": "1:46:38",
+      "source": "both",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 53.0,
+      "label_type": "climb",
+      "label_visual": 8,
+      "label_action": 8,
+      "label_notes": "climb",
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Steep climb up River Road past Palisades rock faces at threshold effort."
+    },
+    {
+      "ride_time_secs": 9202,
+      "ride_time_str": "2:33:22",
+      "source": "both",
+      "clip_name": "GX010346.MP4",
+      "video_secs": 1.0,
+      "label_type": "urban",
+      "label_visual": 8,
+      "label_action": 5,
+      "label_notes": "bridge",
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "landmark",
+      "model_reason": "Cruising toward the iconic George Washington Bridge tower on a sunny day."
+    },
+    {
+      "ride_time_secs": 11253,
+      "ride_time_str": "3:07:33",
+      "source": "both",
+      "clip_name": "GX010350.MP4",
+      "video_secs": 2.0,
+      "label_type": "urban",
+      "label_visual": 8,
+      "label_action": 5,
+      "label_notes": "hudson yards",
+      "model_visual": 8,
+      "model_action": 4,
+      "model_clip_type": "urban",
+      "model_reason": "Cruising past towering Hudson Yards skyscrapers under bright New York skies."
+    }
+  ],
+  "label_only": [
+    {
+      "ride_time_secs": 2591,
+      "ride_time_str": "43:11",
+      "source": "label",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 60.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "George Washington bridge"
+    }
+  ],
+  "model_only": [
+    {
+      "ride_time_secs": 342.4,
+      "ride_time_str": "5:42",
+      "source": "gemini",
+      "clip_name": "GX010333.MP4",
+      "video_secs": 20.4,
+      "model_visual": 6,
+      "model_action": 5,
+      "model_clip_type": "urban",
+      "model_reason": "Golden hour cruise along NYC's West Side path past modern skyline"
+    },
+    {
+      "ride_time_secs": 1552.0,
+      "ride_time_str": "25:52",
+      "source": "gemini",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 54.0,
+      "model_visual": 6,
+      "model_action": 6,
+      "model_clip_type": "urban",
+      "model_reason": "Passing close to MTA city buses on an urban bridge approach."
+    },
+    {
+      "ride_time_secs": 2537.0,
+      "ride_time_str": "42:17",
+      "source": "gemini",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 6.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "descent",
+      "model_reason": "Sun-drenched solo descent down the tree-lined Palisades cliffside road."
+    },
+    {
+      "ride_time_secs": 2574.0,
+      "ride_time_str": "42:54",
+      "source": "gemini",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 43.0,
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "landmark",
+      "model_reason": "Iconic George Washington Bridge reveal climbing up tree-lined River Road."
+    },
+    {
+      "ride_time_secs": 2614.5,
+      "ride_time_str": "43:34",
+      "source": "gemini",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 83.5,
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "landmark",
+      "model_reason": "Cruising under the massive George Washington Bridge with golden hour flare."
+    },
+    {
+      "ride_time_secs": 2641.0,
+      "ride_time_str": "44:01",
+      "source": "gemini",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 110.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "scenery",
+      "model_reason": "Scenic morning cruise along the tree-lined Palisades cliffs with beautiful dappled light."
+    },
+    {
+      "ride_time_secs": 2674.0,
+      "ride_time_str": "44:34",
+      "source": "gemini",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 143.0,
+      "model_visual": 7,
+      "model_action": 4,
+      "model_clip_type": "scenery",
+      "model_reason": "Scenic morning climb past the dramatic Palisades cliffs on River Road."
+    },
+    {
+      "ride_time_secs": 2719.0,
+      "ride_time_str": "45:19",
+      "source": "gemini",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 188.0,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising through dappled morning light on a quiet, wooded park road."
+    },
+    {
+      "ride_time_secs": 3012.0,
+      "ride_time_str": "50:12",
+      "source": "gemini",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 123.0,
+      "model_visual": 7,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Climbing the historic brick road of Fort Tryon Park under dappled sunlight."
+    },
+    {
+      "ride_time_secs": 3142.0,
+      "ride_time_str": "52:22",
+      "source": "gemini",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 253.0,
+      "model_visual": 7,
+      "model_action": 6,
+      "model_clip_type": "descent",
+      "model_reason": "Dynamic high-speed descent down River Road with beautiful dappled morning light."
+    },
+    {
+      "ride_time_secs": 6361.0,
+      "ride_time_str": "1:46:01",
+      "source": "gemini",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 16.0,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Anaerobic climb up steep, cracked road with sun filtering through trees"
+    },
+    {
+      "ride_time_secs": 6425.0,
+      "ride_time_str": "1:47:05",
+      "source": "gemini",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 80.0,
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "High-power anaerobic climb up a rugged, tree-lined historic road."
+    },
+    {
+      "ride_time_secs": 6450.3,
+      "ride_time_str": "1:47:30",
+      "source": "gemini",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 105.3,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Steep anaerobic climb up a quiet, tree-framed road with stone walls."
+    },
+    {
+      "ride_time_secs": 6470.0,
+      "ride_time_str": "1:47:50",
+      "source": "gemini",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 125.0,
+      "model_visual": 4,
+      "model_action": 3,
+      "model_clip_type": "climb",
+      "model_reason": "Solo climb up a quiet, tree-shaded hill at high power."
+    },
+    {
+      "ride_time_secs": 6521.5,
+      "ride_time_str": "1:48:41",
+      "source": "gemini",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 176.5,
+      "model_visual": 4,
+      "model_action": 3,
+      "model_clip_type": "transition",
+      "model_reason": "Unremarkable transit footage on a generic park access road."
+    },
+    {
+      "ride_time_secs": 11308.0,
+      "ride_time_str": "3:08:28",
+      "source": "gemini",
+      "clip_name": "GX010350.MP4",
+      "video_secs": 57.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "urban",
+      "model_reason": "Cruising past modern skyscrapers of Hudson Yards and the High Line."
+    }
+  ]
+}

--- a/samples/2026-07-10/prompt_eval_local_mlx-community-Qwen3-VL-8B-Instruct-3bit_61708849.json
+++ b/samples/2026-07-10/prompt_eval_local_mlx-community-Qwen3-VL-8B-Instruct-3bit_61708849.json
@@ -1,0 +1,389 @@
+{
+  "date_folder": "samples/2026-07-10",
+  "summary": {
+    "provider": "local",
+    "model": "mlx-community/Qwen3-VL-8B-Instruct-3bit",
+    "n_labels": 9,
+    "n_model_hits": 28,
+    "n_matched": 9,
+    "n_label_only": 0,
+    "n_model_only": 19,
+    "precision": 0.321,
+    "recall": 1.0
+  },
+  "patterns": {
+    "model_overflag_by_clip_type": {
+      "scenery": 2,
+      "transition": 10,
+      "climb": 7
+    },
+    "score_agreement": {
+      "n": 9,
+      "visual_mean_diff": -0.89,
+      "action_mean_diff": -1.11
+    },
+    "type_agreement": {
+      "matching": 2,
+      "total": 9,
+      "rate": 0.22
+    },
+    "avg_matched_scores": {
+      "visual": 6.4,
+      "action": 4.9
+    },
+    "avg_model_only_scores": {
+      "visual": 5.7,
+      "action": 4.4
+    },
+    "min_matched_max_score": 4
+  },
+  "matched": [
+    {
+      "ride_time_secs": 351,
+      "ride_time_str": "5:51",
+      "source": "both",
+      "clip_name": "GX010333.MP4",
+      "video_secs": 29.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "pretty flowers",
+      "model_visual": 6,
+      "model_action": 6,
+      "model_clip_type": "urban",
+      "model_reason": "Cruising under city overpass at golden hour, rider visible"
+    },
+    {
+      "ride_time_secs": 1521,
+      "ride_time_str": "25:21",
+      "source": "both",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 23.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "pretty view",
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising toward bridge at golden hour, motion blur on road"
+    },
+    {
+      "ride_time_secs": 2591,
+      "ride_time_str": "43:11",
+      "source": "both",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 60.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "George Washington bridge",
+      "model_visual": 7,
+      "model_action": 6,
+      "model_clip_type": "scenery",
+      "model_reason": "Emerging from trees into skyline reveal, mid-clip"
+    },
+    {
+      "ride_time_secs": 2913,
+      "ride_time_str": "48:33",
+      "source": "both",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 24.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 8,
+      "label_notes": "hudson with speed",
+      "model_visual": 8,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Sunlit trail with lake view, rider cruising at 31mph"
+    },
+    {
+      "ride_time_secs": 4921,
+      "ride_time_str": "1:22:01",
+      "source": "both",
+      "clip_name": "GX010341.MP4",
+      "video_secs": 5.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "9W sign",
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising through shaded forest road, clear path ahead"
+    },
+    {
+      "ride_time_secs": 6347,
+      "ride_time_str": "1:45:47",
+      "source": "both",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 2.0,
+      "label_type": "action",
+      "label_visual": 7,
+      "label_action": 8,
+      "label_notes": "Deer!",
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Deer pauses on trail, rider cruising through forest"
+    },
+    {
+      "ride_time_secs": 6398,
+      "ride_time_str": "1:46:38",
+      "source": "both",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 53.0,
+      "label_type": "climb",
+      "label_visual": 8,
+      "label_action": 8,
+      "label_notes": "climb",
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Climbing uphill through wooded trail, rider visible at peak"
+    },
+    {
+      "ride_time_secs": 9202,
+      "ride_time_str": "2:33:22",
+      "source": "both",
+      "clip_name": "GX010346.MP4",
+      "video_secs": 1.0,
+      "label_type": "urban",
+      "label_visual": 8,
+      "label_action": 5,
+      "label_notes": "bridge",
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "landmark",
+      "model_reason": "Emerging from underbridge into skyline reveal"
+    },
+    {
+      "ride_time_secs": 11253,
+      "ride_time_str": "3:07:33",
+      "source": "both",
+      "clip_name": "GX010350.MP4",
+      "video_secs": 2.0,
+      "label_type": "urban",
+      "label_visual": 8,
+      "label_action": 5,
+      "label_notes": "hudson yards",
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "scenery",
+      "model_reason": "Golden-hour skyline reveal under clear sky, urban grandeur"
+    }
+  ],
+  "label_only": [],
+  "model_only": [
+    {
+      "ride_time_secs": 327.5,
+      "ride_time_str": "5:27",
+      "source": "local",
+      "clip_name": "GX010333.MP4",
+      "video_secs": 5.5,
+      "model_visual": 7,
+      "model_action": 6,
+      "model_clip_type": "scenery",
+      "model_reason": "Early evening ride through urban park with emerging skyline"
+    },
+    {
+      "ride_time_secs": 372.0,
+      "ride_time_str": "6:12",
+      "source": "local",
+      "clip_name": "GX010333.MP4",
+      "video_secs": 50.0,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Underpass transition with construction barriers visible"
+    },
+    {
+      "ride_time_secs": 1503.0,
+      "ride_time_str": "25:03",
+      "source": "local",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 5.0,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Early morning transit through urban park path"
+    },
+    {
+      "ride_time_secs": 1548.0,
+      "ride_time_str": "25:48",
+      "source": "local",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 50.0,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Steady pace under early evening sky, rider centered on road"
+    },
+    {
+      "ride_time_secs": 2536.0,
+      "ride_time_str": "42:16",
+      "source": "local",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 5.0,
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Rising gradient with early morning sun, rider climbing steadily"
+    },
+    {
+      "ride_time_secs": 2626.0,
+      "ride_time_str": "43:46",
+      "source": "local",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 95.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Early-morning climb through wooded path, rider cruising"
+    },
+    {
+      "ride_time_secs": 2671.5,
+      "ride_time_str": "44:31",
+      "source": "local",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 140.5,
+      "model_visual": 7,
+      "model_action": 5,
+      "model_clip_type": "climb",
+      "model_reason": "Cruising up a gentle climb, trees and rock walls frame the road"
+    },
+    {
+      "ride_time_secs": 2716.0,
+      "ride_time_str": "45:16",
+      "source": "local",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 185.0,
+      "model_visual": 8,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Cruising uphill through lush forest, rider centered, clear path ahead"
+    },
+    {
+      "ride_time_secs": 2894.0,
+      "ride_time_str": "48:14",
+      "source": "local",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 5.0,
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "climb",
+      "model_reason": "Rising sun through trees on a gentle climb"
+    },
+    {
+      "ride_time_secs": 2939.5,
+      "ride_time_str": "48:59",
+      "source": "local",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 50.5,
+      "model_visual": 7,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Climbing uphill through green forest, rider visible"
+    },
+    {
+      "ride_time_secs": 2984.0,
+      "ride_time_str": "49:44",
+      "source": "local",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 95.0,
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising under shaded canopy, no landmark or drama"
+    },
+    {
+      "ride_time_secs": 3029.0,
+      "ride_time_str": "50:29",
+      "source": "local",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 140.0,
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising uphill, rider barely visible behind foliage"
+    },
+    {
+      "ride_time_secs": 3074.0,
+      "ride_time_str": "51:14",
+      "source": "local",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 185.0,
+      "model_visual": 6,
+      "model_action": 5,
+      "model_clip_type": "climb",
+      "model_reason": "Climbing a tree-lined hillside road, rider at 246W"
+    },
+    {
+      "ride_time_secs": 3119.0,
+      "ride_time_str": "51:59",
+      "source": "local",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 230.0,
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising through shaded forest with dappled light"
+    },
+    {
+      "ride_time_secs": 3140.0,
+      "ride_time_str": "52:20",
+      "source": "local",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 251.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising through shaded forest with dappled light, rider centered"
+    },
+    {
+      "ride_time_secs": 6443.9,
+      "ride_time_str": "1:47:23",
+      "source": "local",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 98.9,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Cruising up a forested climb, rider visible only at frame 3"
+    },
+    {
+      "ride_time_secs": 6485.0,
+      "ride_time_str": "1:48:05",
+      "source": "local",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 140.0,
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Calm suburban ride, rider cruising through shaded trees"
+    },
+    {
+      "ride_time_secs": 6530.0,
+      "ride_time_str": "1:48:50",
+      "source": "local",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 185.0,
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising through quiet residential streets, uneventful but steady motion."
+    },
+    {
+      "ride_time_secs": 11301.5,
+      "ride_time_str": "3:08:21",
+      "source": "local",
+      "clip_name": "GX010350.MP4",
+      "video_secs": 50.5,
+      "model_visual": 8,
+      "model_action": 6,
+      "model_clip_type": "scenery",
+      "model_reason": "Golden-hour skyline reveal with urban motion blur"
+    }
+  ]
+}

--- a/samples/2026-07-10/prompt_eval_openai_gpt-4.1-mini.json
+++ b/samples/2026-07-10/prompt_eval_openai_gpt-4.1-mini.json
@@ -1,0 +1,346 @@
+{
+  "date_folder": "samples/2026-07-10",
+  "summary": {
+    "provider": "openai",
+    "model": "gpt-4.1-mini",
+    "n_labels": 9,
+    "n_model_hits": 23,
+    "n_matched": 8,
+    "n_label_only": 1,
+    "n_model_only": 15,
+    "precision": 0.348,
+    "recall": 0.889
+  },
+  "patterns": {
+    "model_misses_by_type": {
+      "climb": 1
+    },
+    "model_overflag_by_clip_type": {
+      "urban": 3,
+      "transition": 2,
+      "climb": 5,
+      "descent": 5
+    },
+    "score_agreement": {
+      "n": 8,
+      "visual_mean_diff": -1.62,
+      "action_mean_diff": -2.0
+    },
+    "type_agreement": {
+      "matching": 3,
+      "total": 8,
+      "rate": 0.38
+    },
+    "avg_matched_scores": {
+      "visual": 5.6,
+      "action": 3.8
+    },
+    "avg_model_only_scores": {
+      "visual": 5.5,
+      "action": 3.9
+    },
+    "min_matched_max_score": 4
+  },
+  "matched": [
+    {
+      "ride_time_secs": 351,
+      "ride_time_str": "5:51",
+      "source": "both",
+      "clip_name": "GX010333.MP4",
+      "video_secs": 29.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "pretty flowers",
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "transition",
+      "model_reason": "Ride enters and continues under an urban overpass, enclosed space lowers scenery"
+    },
+    {
+      "ride_time_secs": 1521,
+      "ride_time_str": "25:21",
+      "source": "both",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 23.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "pretty view",
+      "model_visual": 4,
+      "model_action": 4,
+      "model_clip_type": "urban",
+      "model_reason": "Open urban road with distant bridge, moderate speed cruising"
+    },
+    {
+      "ride_time_secs": 2591,
+      "ride_time_str": "43:11",
+      "source": "both",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 60.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "George Washington bridge",
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "descent",
+      "model_reason": "Descent with greenery and bridge glimpse, moderate speed, low power"
+    },
+    {
+      "ride_time_secs": 2913,
+      "ride_time_str": "48:33",
+      "source": "both",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 24.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 8,
+      "label_notes": "hudson with speed",
+      "model_visual": 7,
+      "model_action": 4,
+      "model_clip_type": "descent",
+      "model_reason": "Sunny fast descent past river with open roadway and greenery"
+    },
+    {
+      "ride_time_secs": 4921,
+      "ride_time_str": "1:22:01",
+      "source": "both",
+      "clip_name": "GX010341.MP4",
+      "video_secs": 5.0,
+      "label_type": "scenery",
+      "label_visual": 7,
+      "label_action": 5,
+      "label_notes": "9W sign",
+      "model_visual": 6,
+      "model_action": 3,
+      "model_clip_type": "scenery",
+      "model_reason": "Pleasant quiet road with dappled light but minimal action"
+    },
+    {
+      "ride_time_secs": 6347,
+      "ride_time_str": "1:45:47",
+      "source": "both",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 2.0,
+      "label_type": "action",
+      "label_visual": 7,
+      "label_action": 8,
+      "label_notes": "Deer!",
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Morning light on climb with visible deer and strong gradient"
+    },
+    {
+      "ride_time_secs": 9202,
+      "ride_time_str": "2:33:22",
+      "source": "both",
+      "clip_name": "GX010346.MP4",
+      "video_secs": 1.0,
+      "label_type": "urban",
+      "label_visual": 8,
+      "label_action": 5,
+      "label_notes": "bridge",
+      "model_visual": 6,
+      "model_action": 3,
+      "model_clip_type": "urban",
+      "model_reason": "Bridge walkway with bright light but low motion and weak subject"
+    },
+    {
+      "ride_time_secs": 11253,
+      "ride_time_str": "3:07:33",
+      "source": "both",
+      "clip_name": "GX010350.MP4",
+      "video_secs": 2.0,
+      "label_type": "urban",
+      "label_visual": 8,
+      "label_action": 5,
+      "label_notes": "hudson yards",
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "urban",
+      "model_reason": "Bright city street with strong architectural lines, moderate motion"
+    }
+  ],
+  "label_only": [
+    {
+      "ride_time_secs": 6398,
+      "ride_time_str": "1:46:38",
+      "source": "label",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 53.0,
+      "label_type": "climb",
+      "label_visual": 8,
+      "label_action": 8,
+      "label_notes": "climb"
+    }
+  ],
+  "model_only": [
+    {
+      "ride_time_secs": 329.0,
+      "ride_time_str": "5:29",
+      "source": "openai",
+      "clip_name": "GX010333.MP4",
+      "video_secs": 7.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "urban",
+      "model_reason": "Pleasant early evening light with urban park and city buildings"
+    },
+    {
+      "ride_time_secs": 1506.0,
+      "ride_time_str": "25:06",
+      "source": "openai",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 8.0,
+      "model_visual": 4,
+      "model_action": 2,
+      "model_clip_type": "transition",
+      "model_reason": "Cruising downhill on an ordinary urban street with sunset sky"
+    },
+    {
+      "ride_time_secs": 1546.0,
+      "ride_time_str": "25:46",
+      "source": "openai",
+      "clip_name": "GX010336.MP4",
+      "video_secs": 48.0,
+      "model_visual": 2,
+      "model_action": 2,
+      "model_clip_type": "transition",
+      "model_reason": "Stuck behind a bus on flat road, slow motion, limited subject"
+    },
+    {
+      "ride_time_secs": 2670.0,
+      "ride_time_str": "44:30",
+      "source": "openai",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 139.0,
+      "model_visual": 7,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Climbing a leafy road with dappled sunlight, moderate motion"
+    },
+    {
+      "ride_time_secs": 2693.0,
+      "ride_time_str": "44:53",
+      "source": "openai",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 162.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Golden hour light on leafy climb, moderate motion, no clear subject"
+    },
+    {
+      "ride_time_secs": 2716.0,
+      "ride_time_str": "45:16",
+      "source": "openai",
+      "clip_name": "GX010338.MP4",
+      "video_secs": 185.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "descent",
+      "model_reason": "Nice light and greenery, gentle downhill cruise, no clear subject"
+    },
+    {
+      "ride_time_secs": 2894.0,
+      "ride_time_str": "48:14",
+      "source": "openai",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 5.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "descent",
+      "model_reason": "Descending shaded tree-lined road with nice light but no clear riders"
+    },
+    {
+      "ride_time_secs": 3036.0,
+      "ride_time_str": "50:36",
+      "source": "openai",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 147.0,
+      "model_visual": 6,
+      "model_action": 6,
+      "model_clip_type": "climb",
+      "model_reason": "Sunlight dappled climb on stone path, steady moderate effort"
+    },
+    {
+      "ride_time_secs": 3121.0,
+      "ride_time_str": "52:01",
+      "source": "openai",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 232.0,
+      "model_visual": 6,
+      "model_action": 6,
+      "model_clip_type": "descent",
+      "model_reason": "Speedy descent through dappled woodland light, nice motion and setting"
+    },
+    {
+      "ride_time_secs": 3137.0,
+      "ride_time_str": "52:17",
+      "source": "openai",
+      "clip_name": "GX010339.MP4",
+      "video_secs": 248.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "descent",
+      "model_reason": "Fast descent with sun filtering through trees, no clear subject"
+    },
+    {
+      "ride_time_secs": 4936.0,
+      "ride_time_str": "1:22:16",
+      "source": "openai",
+      "clip_name": "GX010341.MP4",
+      "video_secs": 20.0,
+      "model_visual": 5,
+      "model_action": 4,
+      "model_clip_type": "urban",
+      "model_reason": "Calm ride on tree-lined street, steady pace with good light"
+    },
+    {
+      "ride_time_secs": 6366.0,
+      "ride_time_str": "1:46:06",
+      "source": "openai",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 21.0,
+      "model_visual": 6,
+      "model_action": 5,
+      "model_clip_type": "climb",
+      "model_reason": "Bright tree-lined steep climb with strong power output"
+    },
+    {
+      "ride_time_secs": 6461.0,
+      "ride_time_str": "1:47:41",
+      "source": "openai",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 116.0,
+      "model_visual": 6,
+      "model_action": 4,
+      "model_clip_type": "climb",
+      "model_reason": "Bright shaded climb with strong power, moderate motion"
+    },
+    {
+      "ride_time_secs": 6486.0,
+      "ride_time_str": "1:48:06",
+      "source": "openai",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 141.0,
+      "model_visual": 6,
+      "model_action": 3,
+      "model_clip_type": "urban",
+      "model_reason": "Quiet early morning climb in dappled shade, pleasant trees and houses"
+    },
+    {
+      "ride_time_secs": 6528.0,
+      "ride_time_str": "1:48:48",
+      "source": "openai",
+      "clip_name": "GX010344.MP4",
+      "video_secs": 183.0,
+      "model_visual": 4,
+      "model_action": 3,
+      "model_clip_type": "descent",
+      "model_reason": "Sunny descent with mild speed and shadows, no clear subject"
+    }
+  ]
+}

--- a/samples/README.md
+++ b/samples/README.md
@@ -4,7 +4,7 @@ A real ride you can point the pipeline at. 44.7 miles, 3h09m elapsed, Manhattan
 up 9W and back, recorded on a handlebar GoPro with a Garmin Edge alongside.
 19 chapters, 10,381 GPS points.
 
-The sidecars live here in the repo (~116 KB). The video lives on Hugging Face,
+The sidecars live here in the repo (~216 KB). The video lives on Hugging Face,
 because it is 14 GB.
 
 ## What's in this folder
@@ -13,11 +13,16 @@ because it is 14 GB.
 |---|---|
 | `ride_labels.json` | 9 clips I rated by hand. The ground truth. |
 | `.gemini_cache/` | Gemini's `v10` ratings for all 19 chapters. The baseline. |
+| `.openai_cache/` | GPT-4.1 mini ratings for the 8 labeled chapters. |
+| `.local_cache/` | Local Qwen3-VL 8B 3-bit ratings for the same chapters. |
 | `sync.json` | Per-chapter video↔ride-time offsets from GPMF. |
 | `moments.json` | Merged scan output — what `process` produced from the above. |
+| `prompt_eval_*.json` | Reproducible provider/model comparison reports for issue #2. |
 
-Those four are enough to reproduce the scoring comparison **without downloading
-any video and without a Gemini API key**. That's the point of committing them.
+These are enough to reproduce the scoring comparison **without downloading any
+video and without an API key or local model**. The eight labeled Gemini cache
+files include ride-relative timestamps; when no MP4s are present, `compare`
+uses the label chapter names to select the same evaluation tier for every model.
 
 ## Getting the video
 

--- a/src/gopro_garmin_pipeline/cli.py
+++ b/src/gopro_garmin_pipeline/cli.py
@@ -166,7 +166,7 @@ def require_ffmpeg() -> None:
     Every video path in this project shells out to ffmpeg. Without this the
     first failure is a bare FileNotFoundError from deep inside a worker — and
     inside `process` it surfaces even worse, swallowed by the scan's broad
-    exception handler and reported as "Gemini scan failed", which sends you
+    exception handler and reported as "vision scan failed", which sends you
     debugging the wrong system entirely.
     """
     missing = [t for t in _FFMPEG_TOOLS if shutil.which(t) is None]
@@ -352,8 +352,14 @@ def burn(video_path: Path, fit_file: Path, output: Path | None, offset: float,
 @click.option("--strava-activity", type=int, default=None,
               help="Strava activity ID — injects popular segments as candidates")
 @click.option("--preview", is_flag=True, help="Use fast preview encoding (VideoToolbox) instead of master (libx264)")
-@click.option("--skip-gemini", is_flag=True, help="Skip Gemini vision scan")
-@click.option("--skip-narrative", is_flag=True, help="Skip Gemini narrative selection — fall back to greedy ranking")
+@click.option(
+    "--skip-vision", "--skip-gemini", "skip_gemini", is_flag=True,
+    help="Skip the configured vision-model scan",
+)
+@click.option(
+    "--skip-narrative", is_flag=True,
+    help="Skip model narrative selection — fall back to greedy ranking",
+)
 @click.option("--no-upload", is_flag=True, help="Skip 1080p compress + Drive upload after compose")
 @click.option("--origin", default=None,
               help="Title + start-pin label on the recap card (e.g. 'CENTRAL PARK'). "
@@ -466,7 +472,10 @@ def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_di
 @click.option("--landscape-duration", default=60.0, help="Landscape video duration (seconds)")
 @click.option("--portrait-duration", default=30.0, help="Portrait video duration (seconds)")
 @click.option("--segment-duration", default=3.0, help="Clip segment duration (seconds)")
-@click.option("--skip-gemini", is_flag=True, help="Skip Gemini vision scan")
+@click.option(
+    "--skip-vision", "--skip-gemini", "skip_gemini", is_flag=True,
+    help="Skip the configured vision-model scan",
+)
 @click.option("--skip-review", is_flag=True, help="Skip candidate review, auto-select best")
 @click.option("--no-upload", is_flag=True, help="Skip 1080p compress + Drive upload after compose")
 @click.option("--port", default=8502, help="Port for candidate reviewer")
@@ -508,7 +517,7 @@ def process(date_folder: Path, offset: float, no_auto_sync: bool,
       0. Auto-sync the GoPro and FIT clocks via GPMF GPS (unless
          --offset is explicitly set or --no-auto-sync is passed).
       1. Discover GoPro videos + FIT file in the folder
-      2. Generate candidates from telemetry + Strava + Gemini + labels
+      2. Generate candidates from telemetry + Strava + vision + labels
       3. Launch candidate reviewer (or auto-select if --skip-review)
       4. Compose landscape + portrait videos from selections
     """
@@ -657,7 +666,7 @@ def _process_body(date_folder: Path, offset: float, no_auto_sync: bool,
 
         # Run selection here so we know which moments to mark as `auto`.
         # compose_highlight will re-select internally with the same logic
-        # — same inputs, deterministic output (modulo Gemini narrative
+        # — same inputs, deterministic output (modulo model narrative
         # selection, which is allowed a small amount of nondeterminism).
         from .composer import select_segments
         landscape_segs = select_segments(
@@ -1142,12 +1151,15 @@ def ranker_collect(date_folder, selection_file):
 @main.command("compare-features")
 @click.argument("date_folder", type=click.Path(exists=True))
 @click.option("--strava-activity", type=int, default=None, help="Strava activity ID")
-@click.option("--skip-gemini", is_flag=True, help="Skip Gemini vision scan")
+@click.option(
+    "--skip-vision", "--skip-gemini", "skip_gemini", is_flag=True,
+    help="Skip the configured vision-model scan",
+)
 def compare_features(date_folder, strava_activity, skip_gemini):
-    """Run selection two ways for A/B comparison: greedy vs Gemini narrative.
+    """Run selection two ways for A/B comparison: greedy vs model narrative.
 
     Generates candidates once, then runs selection both with and without
-    Gemini narrative selection. Saves each variant's selection to
+    configured-model narrative selection. Saves each variant's selection to
     <date_folder>/selection_variant_<name>.json for side-by-side review.
     Does NOT burn overlays — use compose-selected on the variant you prefer.
     """

--- a/src/gopro_garmin_pipeline/cli.py
+++ b/src/gopro_garmin_pipeline/cli.py
@@ -967,23 +967,26 @@ def garmin_download(activity_id: int | None, latest: bool, target_date, output_d
 @click.argument("date_folder", type=click.Path(exists=True, path_type=Path))
 @click.option("--offset", default=0.0, help="Time offset in seconds (FIT - GoPro)")
 def compare(date_folder: Path, offset: float):
-    """Compare human labels vs Gemini scan output for a ride.
+    """Compare human labels vs vision-model scan output for a ride.
 
-    DATE_FOLDER: Date folder containing ride_labels.json and .gemini_cache/
+    DATE_FOLDER: Date folder containing ride_labels.json and .{provider}_cache/
 
     Produces a structured comparison report showing:
-      - Matched moments (both human and Gemini agree)
-      - Label-only moments (Gemini missed)
-      - Gemini-only moments (user didn't flag)
+      - Matched moments (both human and model agree)
+      - Label-only moments (model missed)
+      - Model-only moments (user didn't flag)
       - Systematic pattern analysis
+
+    Report is written as prompt_eval_{provider}_{model}.json for the
+    active MODEL_PROVIDER.
     """
-    from .prompt_eval import compare_ride, enrich_gemini_hits_with_ride_time
+    from .prompt_eval import compare_ride, enrich_model_hits_with_ride_time
 
-    # Enrich Gemini cache with ride-relative timestamps for alignment
-    click.echo("Enriching Gemini cache with ride timestamps...")
-    enrich_gemini_hits_with_ride_time(date_folder, offset)
+    # Enrich provider cache with ride-relative timestamps for alignment
+    click.echo("Enriching model cache with ride timestamps...")
+    enrich_model_hits_with_ride_time(date_folder, offset)
 
-    click.echo("\nComparing labels vs Gemini scan...")
+    click.echo("\nComparing labels vs model scan...")
     report = compare_ride(date_folder)
     report.print_summary()
 
@@ -991,13 +994,13 @@ def compare(date_folder: Path, offset: float):
 @main.command("eval-prompt")
 @click.argument("date_folders", nargs=-1, type=click.Path(exists=True, path_type=Path))
 def eval_prompt_cmd(date_folders: tuple[Path, ...]):
-    """Analyze label/Gemini comparison and suggest prompt improvements.
+    """Analyze label/model comparison and suggest prompt improvements.
 
-    DATE_FOLDERS: One or more ride folders with prompt_eval.json files.
+    DATE_FOLDERS: One or more ride folders with comparison reports.
     Run 'compare' first to generate comparison reports.
 
-    Uses Gemini to analyze systematic patterns in what the scan prompt
-    gets right vs wrong, and suggests specific prompt changes.
+    Uses the active MODEL_PROVIDER to analyze systematic patterns in what
+    the scan prompt gets right vs wrong, and suggests specific changes.
     """
     from .prompt_eval import eval_prompt
 

--- a/src/gopro_garmin_pipeline/composer.py
+++ b/src/gopro_garmin_pipeline/composer.py
@@ -5,7 +5,7 @@ Multi-source candidate generation pipeline:
      climbs, sprints detected from Garmin data alone (highlights.py).
   2. Strava segments — popular segments on the route, scored via
      log(star_count) + telemetry at midpoint.
-  3. Gemini vision — sparse frame scan of entire ride for visual interest.
+  3. Vision model — sparse frame scan of entire ride for visual interest.
   4. Manual labels — optional enrichment from ride_labels.json.
 
 All sources are fused, deduplicated (nearby candidates merged), capped
@@ -179,7 +179,7 @@ class ComposerConfig:
     # a halt — are dead footage. Set to 0 to disable the motion-gate.
     min_motion_mph: float = 5.0
     skip_gemini: bool = False
-    skip_narrative: bool = False  # disable Gemini narrative selection (use greedy)
+    skip_narrative: bool = False  # disable model narrative selection (use greedy)
     include_outro: bool = True  # crossfade last segment into recap card
     outro_crossfade_secs: float = 3.0
     outro_lead_in_secs: float = 2.0  # extra normal-playback seconds before crossfade
@@ -300,7 +300,7 @@ def _apply_liveness_penalty(candidates: list[Segment], ride: RideData) -> None:
 
     Skips label-sourced and must-include candidates — the rider's own
     picks are editorial ground truth. Applied to the fused pool BEFORE
-    selection, so the lower scores flow through both the Gemini narrative
+    selection, so the lower scores flow through both the model narrative
     pass (which sees seg.score) and the diversity-aware greedy loop.
     """
     damped = 0
@@ -888,7 +888,7 @@ def _generate_candidates(
     Sources (all optional except ride):
       1. FIT telemetry highlights (always available)
       2. Strava segment efforts (if activity ID provided)
-      3. Gemini vision candidates (if not skipped)
+      3. Vision-model candidates (if not skipped)
       4. Manual labels (if provided)
     """
     all_candidates: list[Segment] = []
@@ -918,7 +918,7 @@ def _generate_candidates(
         print(f"  Strava segments: {len(strava)} candidates")
         all_candidates.extend(strava)
 
-    # 3. Gemini vision
+    # 3. Vision model
     if gemini_candidates:
         src = gemini_candidates[0].source or "vision"
         print(f"  Vision ({src}): {len(gemini_candidates)} candidates")
@@ -1278,7 +1278,7 @@ def _narrative_select(
         seen: set = set()
         _absorb(_call(prompt), selected, seen)
 
-        # Re-ask once if Gemini under-delivered on the count. Models anchor
+        # Re-ask once if the model under-delivered on the count. Models anchor
         # on a short answer and quietly ignore "exactly N" (it returned ~n/2
         # before this). A targeted follow-up naming what's already chosen
         # reliably closes the gap and costs a fraction of a cent.
@@ -1301,7 +1301,8 @@ def _narrative_select(
             return None
 
         selected.sort(key=lambda s: s.ride_time_secs)  # chronological
-        print(f"  Gemini narrative selection: {len(selected)} clips "
+        provider = (settings.model_provider or "gemini").lower()
+        print(f"  Narrative selection ({provider}): {len(selected)} clips "
               f"(target {n_clips})")
         return selected
 
@@ -1323,8 +1324,8 @@ def select_segments(
 ) -> list[Segment]:
     """Two-stage selection: generate candidates, then rank and select for budget.
 
-    First tries Gemini narrative selection (asks Gemini to pick clips that
-    tell a compelling ride story). Falls back to greedy gap-filling on failure.
+    First asks the configured model to pick clips that tell a compelling ride
+    story. Falls back to greedy gap-filling on failure.
 
     If precomputed_candidates is provided, skips candidate generation and
     uses those directly. Otherwise generates from all available sources.
@@ -1352,14 +1353,14 @@ def select_segments(
     # the burn duration, not s.duration.
     n = max(1, int(budget_secs / config.segment_duration))
 
-    # Try Gemini narrative selection first — apply proximity-aware filter
-    # and backfill with greedy if Gemini returned too few or clustered clips.
+    # Try model narrative selection first — apply proximity-aware filter and
+    # backfill with greedy if the model returned too few or clustered clips.
     if not config.skip_narrative:
         narrative = _narrative_select(candidates, n, budget_secs, layout)
         if narrative is not None:
             # Diversity-aware filter. We rank narrative picks by their
             # boosted score (descending) so the strongest claims its spot
-            # first — order-independent of Gemini's story-order response.
+            # first — order-independent of the model's story-order response.
             # A pick survives unless the crowding penalty drives its
             # effective score below zero, i.e., it's clearly net-negative
             # against what's already in. No absolute threshold — that
@@ -1783,7 +1784,7 @@ def generate_all_candidates(
         except Exception as exc:
             print(f"  Warning: couldn't fetch Strava data: {exc}")
 
-    # Optional: Gemini sparse scan
+    # Optional: configured vision-model sparse scan
     gemini_candidates = None
     if not config.skip_gemini:
         try:
@@ -1792,7 +1793,7 @@ def generate_all_candidates(
                 video_dir, synced_clips, ride, config, labels=labels,
             )
         except Exception as exc:
-            print(f"  Warning: Gemini scan failed: {exc}")
+            print(f"  Warning: vision scan failed: {exc}")
 
     # Generate and fuse
     print("\nGenerating candidates...")

--- a/src/gopro_garmin_pipeline/composer.py
+++ b/src/gopro_garmin_pipeline/composer.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .fit_parser import RideData
+from .models import VISION_SOURCES
 from .sync import SyncedClip
 from .utils import MS_TO_MPH, normalize_label_scale, rating_visual_action
 
@@ -605,7 +606,14 @@ def _normalize_scores(candidates: list[Segment]) -> None:
                 s.score = _NON_GEMINI_SCORE_FLOOR + ((s.score - lo) / span) * span_size
 
 
-_SOURCE_PRIORITY = {"label": 0, "telemetry": 1, "strava": 2, "clip": 3, "gemini": 4}
+# Vision providers share the same priority band as historical "gemini".
+_SOURCE_PRIORITY = {
+    "label": 0,
+    "telemetry": 1,
+    "strava": 2,
+    "clip": 3,
+    **{src: 4 for src in VISION_SOURCES},
+}
 
 # Review-cap tunables: fraction of slots filled top-down by score, then the
 # remainder sampled round-robin across these score bands so weak Gemini
@@ -770,16 +778,16 @@ def _fuse_candidates(candidates: list[Segment], cap: int = _CANDIDATE_CAP) -> li
                 fused[i] = winner
                 merged = True
                 break
-            if (same_source and seg.source == "gemini"
+            if (same_source and seg.source in VISION_SOURCES
                     and dt < _GEMINI_DEDUP_WINDOW):
-                # Two Gemini-rated frames this close describe the same
+                # Two vision-rated frames this close describe the same
                 # scene (e.g. the same bridge crossing flagged twice with
                 # slightly different wording). Collapse to the higher-scored
                 # one so the cut never shows the same view back-to-back.
-                # Gemini scores are already rubric-derived (_normalize_scores
+                # Vision scores are already rubric-derived (_normalize_scores
                 # above), so .score IS the visual-quality comparison. Gated to
-                # Gemini on purpose: adjacent telemetry spikes ARE independent
-                # events and must stay separate.
+                # vision sources on purpose: adjacent telemetry spikes ARE
+                # independent events and must stay separate.
                 winner = seg if seg.score > existing.score else existing
                 _union_review_window(winner, seg, existing)
                 fused[i] = winner
@@ -814,7 +822,7 @@ def _fuse_candidates(candidates: list[Segment], cap: int = _CANDIDATE_CAP) -> li
     for seg in fused:
         if seg.rubric:
             continue
-        if "gemini" in seg.sources:
+        if VISION_SOURCES.intersection(seg.sources):
             continue
         if seg.score > _BLIND_TELEMETRY_CEILING:
             seg.score = _BLIND_TELEMETRY_CEILING
@@ -912,7 +920,8 @@ def _generate_candidates(
 
     # 3. Gemini vision
     if gemini_candidates:
-        print(f"  Gemini vision: {len(gemini_candidates)} candidates")
+        src = gemini_candidates[0].source or "vision"
+        print(f"  Vision ({src}): {len(gemini_candidates)} candidates")
         all_candidates.extend(gemini_candidates)
 
     # 4. Manual labels
@@ -1180,17 +1189,18 @@ def _narrative_select(
     budget_secs: float,
     layout: str = "landscape",
 ) -> list[Segment] | None:
-    """Ask Gemini to select clips that tell a compelling ride story.
+    """Ask the configured model to select clips that tell a ride story.
 
     Passes the full candidate list with timestamps, scores, descriptions, and
-    clip types. Gemini returns indices of selected clips in narrative order.
+    clip types. Returns indices of selected clips in narrative order.
     Falls back to None on any failure (caller should use greedy selection).
+    Uses the same MODEL_PROVIDER as the vision scan — never a second provider.
     """
     from .config import get_settings
-    from .utils import parse_json_response
+    from .models import get_model_adapter, provider_api_key
 
     settings = get_settings()
-    if not settings.gemini_api_key:
+    if not provider_api_key(settings):
         return None
 
     candidates = sorted(candidates, key=lambda s: s.ride_time_secs)
@@ -1200,7 +1210,7 @@ def _narrative_select(
     for i, seg in enumerate(candidates):
         notes = seg.label.get("notes", "")[:60]
         clip_type = seg.label.get("clip_type", seg.label.get("type", ""))
-        # Gemini candidates carry a rubric, not visual/action — read through
+        # Vision candidates carry a rubric, not visual/action — read through
         # the fold so they don't all report 0 to the selector.
         visual, action = rating_visual_action(seg.label)
         sources = ",".join(seg.sources) if seg.sources else seg.source
@@ -1232,22 +1242,14 @@ def _narrative_select(
     )
 
     def _call(prompt_text: str) -> list:
-        """One Gemini call → flat list of candidate indices (flattening any
+        """One model call → flat list of candidate indices (flattening any
         nested arrays like [[0],[5]]). Empty list on a non-list response."""
-        from google import genai
-        from google.genai import types
-
-        client = genai.Client(api_key=settings.gemini_api_key)
-        response = client.models.generate_content(
-            model=settings.gemini_model,
-            contents=[types.Content(parts=[types.Part.from_text(text=prompt_text)])],
-            config=types.GenerateContentConfig(
-                temperature=0.3,
-                max_output_tokens=1024,
-                thinking_config=types.ThinkingConfig(thinking_budget=256),
-            ),
+        adapter = get_model_adapter(settings)
+        result = adapter.complete_json(
+            prompt=prompt_text,
+            temperature=0.3,
+            max_output_tokens=1024,
         )
-        result = parse_json_response(response.text)
         if not isinstance(result, list):
             return []
         flat = []

--- a/src/gopro_garmin_pipeline/config.py
+++ b/src/gopro_garmin_pipeline/config.py
@@ -22,9 +22,18 @@ class Settings(BaseSettings):
     strava_client_id: str = ""
     strava_client_secret: str = ""
 
+    # --- Model provider (one provider powers the entire run) ---
+    # gemini (default) | openai. Vision scan, narrative select, and prompt
+    # eval all use this provider — never mixed in a single run.
+    model_provider: str = "gemini"
+
     # --- Gemini ---
     gemini_api_key: str = ""
     gemini_model: str = "gemini-3.5-flash"
+
+    # --- OpenAI ---
+    openai_api_key: str = ""
+    openai_model: str = "gpt-4.1-mini"
 
     # --- OpenStreetMap ---
     # Nominatim and Overpass require a contact address on every request so

--- a/src/gopro_garmin_pipeline/config.py
+++ b/src/gopro_garmin_pipeline/config.py
@@ -23,8 +23,8 @@ class Settings(BaseSettings):
     strava_client_secret: str = ""
 
     # --- Model provider (one provider powers the entire run) ---
-    # gemini (default) | openai. Vision scan, narrative select, and prompt
-    # eval all use this provider — never mixed in a single run.
+    # gemini (default) | openai | local. Vision scan, narrative select, and
+    # prompt eval all use this provider — never mixed in a single run.
     model_provider: str = "gemini"
 
     # --- Gemini ---
@@ -34,6 +34,15 @@ class Settings(BaseSettings):
     # --- OpenAI ---
     openai_api_key: str = ""
     openai_model: str = "gpt-4.1-mini"
+
+    # --- Local OpenAI-compatible VLM (MLX-VLM / Ollama / LM Studio / vLLM) ---
+    # Used when MODEL_PROVIDER=local. Prefers json_schema structured outputs
+    # (MLX-VLM); falls back to free-form JSON for less capable servers.
+    local_base_url: str = "http://localhost:8080/v1"
+    local_api_key: str = "local"
+    local_model: str = ""
+    local_max_concurrency: int = 1
+    local_timeout_seconds: float = 600.0
 
     # --- OpenStreetMap ---
     # Nominatim and Overpass require a contact address on every request so

--- a/src/gopro_garmin_pipeline/gemini_scan.py
+++ b/src/gopro_garmin_pipeline/gemini_scan.py
@@ -34,8 +34,9 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
+from .models import ModelAdapter, cache_dir_name, get_model_adapter, provider_api_key
 from .prompt_registry import prompt_body
-from .utils import MS_TO_MPH, compute_gradient, gopro_lrv_proxy, parse_json_response
+from .utils import MS_TO_MPH, compute_gradient, gopro_lrv_proxy
 
 
 # ─── Scan parameters ─────────────────────────────────────────
@@ -67,10 +68,6 @@ _MAX_WORKERS = 4        # concurrent Gemini API calls
 _PROMPT_VERSION = "v10"
 _CACHE_VERSION = _PROMPT_VERSION  # cache key tracks prompt version
 _SYSTEM_INSTRUCTION = prompt_body("gemini_scan", _PROMPT_VERSION)
-
-# Per-request timeout (seconds × 1000 = ms in HttpOptions). Without this,
-# a stuck Gemini connection hangs forever instead of triggering retry.
-_REQUEST_TIMEOUT_MS = 180_000
 
 # Coarse pass still uses the v5 frame-rating prompt for region detection
 _COARSE_PROMPT_VERSION = "v5"
@@ -368,119 +365,98 @@ class _ScanErrors:
                     self.samples.append(s)
 
 
-def _get_client(settings):
-    """Create a Gemini client (import on first use)."""
-    from google import genai
-    return genai.Client(api_key=settings.gemini_api_key)
-
-
-def _call_batch(
-    client,
-    frame_paths: list[Path],
-    telemetry_text: str,
-    n_frames: int,
-    interval: float,
-    settings,
-    has_power: bool = True,
-) -> list[dict]:
-    """Coarse pass — score N frames individually using v5 frame-rating prompt."""
-    from google.genai import types
-
-    parts = []
+def _read_images(frame_paths: list[Path]) -> list[bytes]:
+    images: list[bytes] = []
     for fp in frame_paths:
         with open(fp, "rb") as f:
-            data = f.read()
-        parts.append(types.Part.from_bytes(data=data, mime_type="image/jpeg"))
+            images.append(f.read())
+    return images
 
-    user_text = _BATCH_TEMPLATE.format(
-        n_frames=n_frames, interval=interval, telemetry=telemetry_text,
-    )
-    parts.append(types.Part.from_text(text=user_text))
 
+def _coarse_prompts(
+    telemetry_text: str, n_frames: int, interval: float, has_power: bool,
+) -> tuple[str, str]:
+    """Build system + user text for the coarse (v5) pass."""
     from .config import get_settings as _get_settings
     _s = _get_settings()
     power_zones, telemetry_fields, telemetry_examples = _build_context_strings(
         has_power, _s.ftp,
     )
-
     system_text = _COARSE_SYSTEM_INSTRUCTION.format(
         min_visual=_COARSE_MIN_VISUAL, min_action=_COARSE_MIN_ACTION,
         power_zones=power_zones,
         telemetry_fields=telemetry_fields,
         telemetry_examples=telemetry_examples,
     )
-
-    response = client.models.generate_content(
-        model=settings.gemini_model,
-        contents=[types.Content(parts=parts)],
-        config=types.GenerateContentConfig(
-            system_instruction=system_text,
-            http_options=types.HttpOptions(timeout=_REQUEST_TIMEOUT_MS),
-        ),
+    user_text = _BATCH_TEMPLATE.format(
+        n_frames=n_frames, interval=interval, telemetry=telemetry_text,
     )
-
-    result = parse_json_response(response.text)
-    return result if isinstance(result, list) else []
+    return system_text, user_text
 
 
-def _call_clip_rubric(
-    client,
-    frame_paths: list[Path],
-    telemetry_text: str,
-    duration: float,
-    settings,
-    has_power: bool = True,
-) -> dict | None:
-    """Clip pass — rate one clip on the 5-dim rubric using v6 prompt."""
-    from google.genai import types
-
-    parts = []
-    for fp in frame_paths:
-        with open(fp, "rb") as f:
-            data = f.read()
-        parts.append(types.Part.from_bytes(data=data, mime_type="image/jpeg"))
-
-    user_text = _CLIP_TEMPLATE.format(
-        duration=duration, n_frames=len(frame_paths), telemetry=telemetry_text,
-    )
-    parts.append(types.Part.from_text(text=user_text))
-
+def _fine_prompts(
+    telemetry_text: str, duration: float, n_frames: int, has_power: bool,
+) -> tuple[str, str]:
+    """Build system + user text for the fine rubric pass."""
     from .config import get_settings as _get_settings
     _s = _get_settings()
     power_zones, telemetry_fields, telemetry_examples = _build_context_strings(
         has_power, _s.ftp,
     )
-
     system_text = _SYSTEM_INSTRUCTION.format(
-        n_frames=len(frame_paths),
+        n_frames=n_frames,
         power_zones=power_zones,
         telemetry_fields=telemetry_fields,
         telemetry_examples=telemetry_examples,
     )
+    user_text = _CLIP_TEMPLATE.format(
+        duration=duration, n_frames=n_frames, telemetry=telemetry_text,
+    )
+    return system_text, user_text
 
-    response = client.models.generate_content(
-        model=settings.gemini_model,
-        contents=[types.Content(parts=parts)],
-        config=types.GenerateContentConfig(
-            system_instruction=system_text,
-            http_options=types.HttpOptions(timeout=_REQUEST_TIMEOUT_MS),
-        ),
+
+def _call_batch(
+    adapter: ModelAdapter,
+    frame_paths: list[Path],
+    telemetry_text: str,
+    n_frames: int,
+    interval: float,
+    has_power: bool = True,
+) -> list[dict]:
+    """Coarse pass — score N frames individually using v5 frame-rating prompt."""
+    system_text, user_text = _coarse_prompts(
+        telemetry_text, n_frames, interval, has_power,
+    )
+    return adapter.score_frames(
+        images=_read_images(frame_paths),
+        system=system_text,
+        user=user_text,
     )
 
-    result = parse_json_response(response.text)
-    if isinstance(result, dict):
-        return result
-    if isinstance(result, list) and result:
-        first = result[0]
-        return first if isinstance(first, dict) else None
-    return None
+
+def _call_clip_rubric(
+    adapter: ModelAdapter,
+    frame_paths: list[Path],
+    telemetry_text: str,
+    duration: float,
+    has_power: bool = True,
+) -> dict | None:
+    """Clip pass — rate one clip on the 5-dim rubric."""
+    system_text, user_text = _fine_prompts(
+        telemetry_text, duration, len(frame_paths), has_power,
+    )
+    return adapter.score_clip_rubric(
+        images=_read_images(frame_paths),
+        system=system_text,
+        user=user_text,
+    )
 
 
 def _call_with_retry(
-    client, frame_paths, telemetry_text, n_frames, interval, settings,
+    adapter: ModelAdapter, frame_paths, telemetry_text, n_frames, interval,
     label: str = "", has_power: bool = True, errors: _ScanErrors | None = None,
 ) -> list[dict] | None:
-    """Call Gemini with exponential backoff on transient errors.
+    """Call the vision adapter with exponential backoff on transient errors.
 
     Returns the parsed result on success (including a legitimately empty
     list). Returns None only when the call HARD-FAILS — a non-retryable
@@ -491,11 +467,13 @@ def _call_with_retry(
     last_err = ""
     for attempt in range(5):
         try:
-            return _call_batch(client, frame_paths, telemetry_text, n_frames, interval, settings,
-                               has_power=has_power)
+            return _call_batch(
+                adapter, frame_paths, telemetry_text, n_frames, interval,
+                has_power=has_power,
+            )
         except Exception as e:
             last_err = str(e)
-            if any(code in last_err for code in ("503", "429", "UNAVAILABLE")):
+            if adapter.is_transient_error(e):
                 wait = 2 ** attempt * 5
                 print(f"    {label}: {last_err[:80]}... retrying in {wait}s")
                 time.sleep(wait)
@@ -511,9 +489,6 @@ def _call_with_retry(
 
 # ─── Per-clip caching ────────────────────────────────────────
 
-_CACHE_DIR_NAME = ".gemini_cache"
-
-
 def _label_fingerprint(forced_fine_times: list[float] | None) -> str:
     """Short stable digest of label-forced timestamps for cache keying.
 
@@ -528,24 +503,44 @@ def _label_fingerprint(forced_fine_times: list[float] | None) -> str:
     return hashlib.sha1(sig.encode()).hexdigest()[:8]
 
 
+def _model_fingerprint(model_id: str) -> str:
+    return hashlib.sha1(model_id.encode()).hexdigest()[:8]
+
+
 def _clip_cache_key(
-    clip_name: str, forced_fine_times: list[float] | None = None,
+    clip_name: str,
+    forced_fine_times: list[float] | None = None,
+    *,
+    provider: str = "gemini",
+    model_id: str = "",
 ) -> str:
-    """Stable filename-safe cache key for a clip + scan version + labels."""
+    """Stable filename-safe cache key for a clip + scan version + labels.
+
+    Gemini keeps legacy filenames (no model fingerprint). Other providers
+    include ``_m{model_fp}`` so changing OPENAI_MODEL cannot reuse ratings.
+    """
     stem = Path(clip_name).stem
+    parts = [stem, _CACHE_VERSION]
+    if provider != "gemini" and model_id:
+        parts.append(f"m{_model_fingerprint(model_id)}")
     fp = _label_fingerprint(forced_fine_times)
     if fp:
-        return f"{stem}_{_CACHE_VERSION}_l{fp}.json"
-    return f"{stem}_{_CACHE_VERSION}.json"
+        parts.append(f"l{fp}")
+    return "_".join(parts) + ".json"
 
 
 def _load_clip_cache(
     video_dir: Path, clip_name: str,
     forced_fine_times: list[float] | None = None,
+    *,
+    provider: str = "gemini",
+    model_id: str = "",
 ) -> list[dict] | None:
-    """Load cached hits for a single clip + label set."""
-    cache_dir = video_dir / _CACHE_DIR_NAME
-    cache_file = cache_dir / _clip_cache_key(clip_name, forced_fine_times)
+    """Load cached hits for a single clip + label set + provider/model."""
+    cache_dir = video_dir / cache_dir_name(provider)
+    cache_file = cache_dir / _clip_cache_key(
+        clip_name, forced_fine_times, provider=provider, model_id=model_id,
+    )
     if not cache_file.exists():
         return None
     try:
@@ -560,11 +555,16 @@ def _load_clip_cache(
 def _save_clip_cache(
     video_dir: Path, clip_name: str, hits: list[dict],
     forced_fine_times: list[float] | None = None,
+    *,
+    provider: str = "gemini",
+    model_id: str = "",
 ) -> None:
-    """Save raw hits for a single clip + label set."""
-    cache_dir = video_dir / _CACHE_DIR_NAME
+    """Save raw hits for a single clip + label set + provider/model."""
+    cache_dir = video_dir / cache_dir_name(provider)
     cache_dir.mkdir(exist_ok=True)
-    cache_file = cache_dir / _clip_cache_key(clip_name, forced_fine_times)
+    cache_file = cache_dir / _clip_cache_key(
+        clip_name, forced_fine_times, provider=provider, model_id=model_id,
+    )
     cache_file.write_text(json.dumps(hits, indent=2))
 
 
@@ -584,25 +584,32 @@ def _scan_clip(
         whole on the 5-dim rubric.
 
     forced_fine_times: video_secs positions that must be rated regardless
-        of coarse scores. Used to ensure Gemini sees every labeled moment.
+        of coarse scores. Used to ensure the model sees every labeled moment.
     """
     clip = sc.clip
     clip_name = clip.path.name
 
+    # Per-clip adapter so nested thread pools do not share one client.
+    adapter = get_model_adapter(settings)
+    provider = adapter.name
+    model_id = adapter.model_id
+
     # Cache key folds in the label fingerprint so adding or editing
-    # manual labels invalidates a cached scan and Gemini gets to score
+    # manual labels invalidates a cached scan and the model gets to score
     # the newly forced regions on the next run.
-    cached = _load_clip_cache(video_dir, clip_name, forced_fine_times)
+    cached = _load_clip_cache(
+        video_dir, clip_name, forced_fine_times,
+        provider=provider, model_id=model_id,
+    )
     if cached is not None:
         print(f"  {clip_name}: {len(cached)} clips (cached)")
         return cached
 
-    client = _get_client(settings)
     # Per-clip failure tally — gates caching so a transient API outage
     # is never persisted as "scanned, found nothing."
     errors = _ScanErrors()
 
-    with tempfile.TemporaryDirectory(prefix="gemini_coarse_") as tmpdir:
+    with tempfile.TemporaryDirectory(prefix="vlm_coarse_") as tmpdir:
         # ── Pass 1: coarse scan ───────────────────────────────
         print(f"  {clip_name}: coarse pass ({clip.duration_secs:.0f}s, 1 frame/{_COARSE_INTERVAL}s)...")
         coarse_frames = _extract_sparse_frames(
@@ -610,11 +617,14 @@ def _scan_clip(
             clip_duration=clip.duration_secs,
         )
         if not coarse_frames:
-            _save_clip_cache(video_dir, clip_name, [], forced_fine_times)
+            _save_clip_cache(
+                video_dir, clip_name, [], forced_fine_times,
+                provider=provider, model_id=model_id,
+            )
             return []
 
         coarse_hits = _run_batches_parallel(
-            client, coarse_frames, sc, ride, settings,
+            adapter, coarse_frames, sc, ride, settings,
             batch_size=_COARSE_BATCH, interval=_COARSE_INTERVAL,
             label_prefix=f"{clip_name} coarse",
             errors=errors,
@@ -629,7 +639,7 @@ def _scan_clip(
                 hot_times.append(h["video_secs"])
 
         # Inject forced times from labels, telemetry peaks, and coverage
-        # samples. Gemini scores blind (no label/source text), but every
+        # samples. Model scores blind (no label/source text), but every
         # forced moment gets a fair rubric rating.
         if forced_fine_times:
             n_added = 0
@@ -642,13 +652,16 @@ def _scan_clip(
 
         if not hot_times:
             if errors.count:
-                print(f"  ⚠ {clip_name}: coarse pass had {errors.count} Gemini "
+                print(f"  ⚠ {clip_name}: coarse pass had {errors.count} "
                       f"failure(s) — NOT caching empty result (will retry next run)")
                 if agg_errors is not None:
                     agg_errors.merge(errors)
                 return []
             print(f"  {clip_name}: no interesting regions found in coarse pass")
-            _save_clip_cache(video_dir, clip_name, [], forced_fine_times)
+            _save_clip_cache(
+                video_dir, clip_name, [], forced_fine_times,
+                provider=provider, model_id=model_id,
+            )
             return []
 
         # Build candidate clips (±_CLIP_PAD around each hot timestamp) and
@@ -663,24 +676,27 @@ def _scan_clip(
 
     # ── Pass 2: clip rubric rating ────────────────────────────
     clip_results = _rate_candidate_clips(
-        client, clip.path, clip_name, candidate_clips,
+        adapter, clip.path, clip_name, candidate_clips,
         sc, ride, settings, errors=errors,
     )
     print(f"  {clip_name}: {len(clip_results)} clips rated by rubric")
 
     if errors.count:
-        print(f"  ⚠ {clip_name}: {errors.count} Gemini failure(s) during scan — "
+        print(f"  ⚠ {clip_name}: {errors.count} failure(s) during scan — "
               f"NOT caching {len(clip_results)} partial result(s) (will retry next run)")
         if agg_errors is not None:
             agg_errors.merge(errors)
         return clip_results
 
-    _save_clip_cache(video_dir, clip_name, clip_results, forced_fine_times)
+    _save_clip_cache(
+        video_dir, clip_name, clip_results, forced_fine_times,
+        provider=provider, model_id=model_id,
+    )
     return clip_results
 
 
 def _rate_candidate_clips(
-    client, video_path: Path, clip_name: str,
+    adapter: ModelAdapter, video_path: Path, clip_name: str,
     candidate_clips: list[tuple[float, float]],
     sc, ride, settings, errors: _ScanErrors | None = None,
 ) -> list[dict]:
@@ -696,7 +712,7 @@ def _rate_candidate_clips(
         duration = end - start
         if duration <= 0:
             return None
-        with tempfile.TemporaryDirectory(prefix="gemini_clip_") as tmpdir:
+        with tempfile.TemporaryDirectory(prefix="vlm_clip_") as tmpdir:
             # Sample N evenly-spaced frames from this clip
             interval = duration / max(1, _FRAMES_PER_CLIP)
             samples = _extract_region_frames(
@@ -710,8 +726,8 @@ def _rate_candidate_clips(
             telemetry = _build_clip_telemetry(sc, ride, start, end)
             label = f"{clip_name} clip {idx + 1}/{n_total}"
             result = _call_clip_with_retry(
-                client, [p for _, p in samples], telemetry,
-                duration, settings, label=label, has_power=has_power,
+                adapter, [p for _, p in samples], telemetry,
+                duration, label=label, has_power=has_power,
                 errors=errors,
             )
             if not result:
@@ -723,7 +739,7 @@ def _rate_candidate_clips(
             rubric = {k: int(result.get(k, 0)) for k in rubric_keys}
             raw_sum = sum(rubric.values())
 
-            # Gemini-picked best 3-second window inside the clip.
+            # Model-picked best 3-second window inside the clip.
             # peak_offset 0.0-1.0 maps to start..end. Default to 0.5
             # (midpoint) if the model didn't return one. Clamp to [0,1].
             peak_offset = float(result.get("peak_offset", 0.5))
@@ -765,7 +781,7 @@ def _rate_candidate_clips(
 
 
 def _call_clip_with_retry(
-    client, frame_paths, telemetry_text, duration, settings,
+    adapter: ModelAdapter, frame_paths, telemetry_text, duration,
     label: str = "", has_power: bool = True, errors: _ScanErrors | None = None,
 ) -> dict | None:
     """Call clip rubric with exponential backoff on transient errors.
@@ -779,12 +795,12 @@ def _call_clip_with_retry(
     for attempt in range(5):
         try:
             return _call_clip_rubric(
-                client, frame_paths, telemetry_text, duration,
-                settings, has_power=has_power,
+                adapter, frame_paths, telemetry_text, duration,
+                has_power=has_power,
             )
         except Exception as e:
             last_err = str(e)
-            if any(code in last_err for code in ("503", "429", "UNAVAILABLE")):
+            if adapter.is_transient_error(e):
                 wait = 2 ** attempt * 5
                 print(f"    {label}: {last_err[:80]}... retrying in {wait}s")
                 time.sleep(wait)
@@ -826,7 +842,7 @@ def _merge_regions(
 # ─── Parallel batch runner ───────────────────────────────────
 
 def _run_batches_parallel(
-    client,
+    adapter: ModelAdapter,
     frames: list[tuple[float, Path]],
     sc, ride, settings,
     batch_size: int,
@@ -851,7 +867,7 @@ def _run_batches_parallel(
         label = f"{label_prefix} {batch_num + 1}/{n_batches}"
 
         results = _call_with_retry(
-            client, batch_paths, telemetry, len(batch), interval, settings,
+            adapter, batch_paths, telemetry, len(batch), interval,
             label=label, has_power=has_power, errors=errors,
         )
         if results is None:
@@ -910,6 +926,8 @@ def _run_batches_parallel(
 
 def _hits_to_segments(
     hits: list[dict], synced_clips: list, ride, config,
+    *,
+    provider: str = "gemini",
 ) -> list:
     """Convert clip rubric results to Segment candidates.
 
@@ -923,6 +941,7 @@ def _hits_to_segments(
 
     clip_by_name = {sc.clip.path.name: sc for sc in synced_clips}
     candidates = []
+    vision_type = f"{provider}_vision"
 
     for h in hits:
         clip_name = h["clip_name"]
@@ -970,12 +989,12 @@ def _hits_to_segments(
             ride_time_secs=ride_secs,
             anchor_video_secs=anchor,
             score=score,
-            source="gemini",
+            source=provider,
             rubric=rubric,
             portrait_crop_bias=crop_bias,
             label={
                 "ride_time_secs": ride_secs,
-                "type": "gemini_vision",
+                "type": vision_type,
                 "notes": reason,
                 "clip_name": clip_name,
                 "video_secs": anchor,
@@ -1074,7 +1093,7 @@ def scan_ride(
     config,
     labels: list[dict] | None = None,
 ) -> list:
-    """Scan entire ride with Gemini vision, return Segment candidates.
+    """Scan entire ride with the configured vision model, return Segment candidates.
 
     Two-pass strategy:
       1. Coarse: 1 frame/10s → find interesting regions
@@ -1083,7 +1102,7 @@ def scan_ride(
     Per-clip caching means only new/changed clips get scanned.
 
     If labels are provided, their timestamps are injected as forced
-    fine-pass regions so Gemini always scores labeled moments (blind —
+    fine-pass regions so the model always scores labeled moments (blind —
     no label text in the prompt).
     """
     from .config import get_settings
@@ -1091,16 +1110,24 @@ def scan_ride(
     video_dir = Path(video_dir)
 
     settings = get_settings()
-    if not settings.gemini_api_key:
-        print("  Gemini scan: no API key configured, skipping")
+    provider = (settings.model_provider or "gemini").lower()
+    if not provider_api_key(settings):
+        print(f"  Vision scan ({provider}): no API key configured, skipping")
         return []
+
+    # Resolve model_id for cache probes without constructing a client when
+    # we only need the fingerprint for cache-hit counting below.
+    if provider == "openai":
+        model_id = settings.openai_model
+    else:
+        model_id = settings.gemini_model
 
     # Build per-clip forced fine-pass times from labels + telemetry peaks.
     # The coarse pass at 1 frame / 10s misses fast events — a corner taken
     # at speed, a brief sprint, a 3-second descent — because the sample
     # frames don't land on the action. Telemetry knows exactly when the
     # speed/power/HR/climb peaks were; we hand those video timestamps to
-    # Gemini directly so the rubric pass scores them no matter what the
+    # the model directly so the rubric pass scores them no matter what the
     # coarse pass thought.
     forced_by_clip: dict[str, list[float]] = {}
 
@@ -1112,20 +1139,24 @@ def scan_ride(
                 forced_by_clip.setdefault(clip_name, []).append(video_secs)
         n_labels = sum(len(v) for v in forced_by_clip.values())
         if n_labels:
-            print(f"  Gemini scan: {n_labels} label timestamps forced into fine pass")
+            print(f"  Vision scan ({provider}): {n_labels} label timestamps "
+                  f"forced into fine pass")
 
     # Telemetry peak injection: detect highlights and map each peak_time
     # back to a (clip_name, video_secs) inside one of the synced clips.
     # Uses each SyncedClip's timezone-normalized clip-start to invert.
     n_telemetry = _inject_telemetry_peaks(forced_by_clip, ride, synced_clips)
     if n_telemetry:
-        print(f"  Gemini scan: {n_telemetry} telemetry peaks forced into fine pass")
+        print(f"  Vision scan ({provider}): {n_telemetry} telemetry peaks "
+              f"forced into fine pass")
 
     n_coverage = _inject_coverage_samples(forced_by_clip, synced_clips)
     if n_coverage:
-        print(f"  Gemini scan: {n_coverage} coverage samples forced into fine pass")
+        print(f"  Vision scan ({provider}): {n_coverage} coverage samples "
+              f"forced into fine pass")
 
-    # Scan clips in parallel — each clip gets its own coarse+fine pass.
+    # Scan clips in parallel — each clip gets its own coarse+fine pass
+    # and its own adapter/client instance.
     # scan_errors aggregates hard API failures across every clip so a
     # total outage triggers a loud warning instead of silently returning
     # an empty (and therefore telemetry-only) candidate set.
@@ -1141,7 +1172,7 @@ def scan_ride(
             all_hits.extend(hits)
     else:
         print(f"  Scanning {len(synced_clips)} clips in parallel...")
-        # Clip-level threads overlap Gemini API waits with ffmpeg extraction.
+        # Clip-level threads overlap API waits with ffmpeg extraction.
         # Actual ffmpeg concurrency is capped by _FFMPEG_SEMAPHORE (default 2).
         with ThreadPoolExecutor(max_workers=len(synced_clips)) as pool:
             futures = {
@@ -1163,15 +1194,17 @@ def scan_ride(
         if _load_clip_cache(
             video_dir, sc.clip.path.name,
             forced_by_clip.get(sc.clip.path.name),
+            provider=provider, model_id=model_id,
         ) is not None
     )
-    print(f"  Gemini scan: {len(all_hits)} total hits across {len(synced_clips)} clips "
-          f"({total_cached} from cache)")
+    print(f"  Vision scan ({provider}): {len(all_hits)} total hits across "
+          f"{len(synced_clips)} clips ({total_cached} from cache)")
 
     if scan_errors.count:
         print(
             "\n  " + "!" * 64 + "\n"
-            f"  ⚠️  GEMINI SCAN DEGRADED — {scan_errors.count} API call(s) hard-failed.\n"
+            f"  ⚠️  VISION SCAN DEGRADED ({provider}) — "
+            f"{scan_errors.count} API call(s) hard-failed.\n"
             "      Visual candidates are INCOMPLETE; affected clips fall back to\n"
             "      telemetry/filler only. Failed clips were NOT cached, so a\n"
             "      re-run will retry them once the API is healthy.\n"
@@ -1179,6 +1212,8 @@ def scan_ride(
             "  " + "!" * 64 + "\n"
         )
 
-    candidates = _hits_to_segments(all_hits, synced_clips, ride, config)
-    print(f"  Gemini scan: {len(candidates)} interesting moments")
+    candidates = _hits_to_segments(
+        all_hits, synced_clips, ride, config, provider=provider,
+    )
+    print(f"  Vision scan ({provider}): {len(candidates)} interesting moments")
     return candidates

--- a/src/gopro_garmin_pipeline/gemini_scan.py
+++ b/src/gopro_garmin_pipeline/gemini_scan.py
@@ -34,7 +34,13 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from .models import ModelAdapter, cache_dir_name, get_model_adapter, provider_api_key
+from .models import (
+    ModelAdapter,
+    cache_dir_name,
+    get_model_adapter,
+    provider_api_key,
+    provider_model_id,
+)
 from .prompt_registry import prompt_body
 from .utils import MS_TO_MPH, compute_gradient, gopro_lrv_proxy
 
@@ -1117,10 +1123,7 @@ def scan_ride(
 
     # Resolve model_id for cache probes without constructing a client when
     # we only need the fingerprint for cache-hit counting below.
-    if provider == "openai":
-        model_id = settings.openai_model
-    else:
-        model_id = settings.gemini_model
+    model_id = provider_model_id(settings)
 
     # Build per-clip forced fine-pass times from labels + telemetry peaks.
     # The coarse pass at 1 frame / 10s misses fast events — a corner taken

--- a/src/gopro_garmin_pipeline/learned_ranker.py
+++ b/src/gopro_garmin_pipeline/learned_ranker.py
@@ -84,11 +84,15 @@ def _extract_features(seg_data: dict) -> dict[str, float]:
     sources = seg_data.get("sources", [])
     source_count = float(len(sources)) if sources else 1.0
 
-    # Source presence flags
-    has_gemini = float("gemini" in sources)
+    # Source presence flags.
+    # Feature name stays ``has_gemini`` for training-file / weight compat;
+    # compute as any vision provider so OpenAI-scored clips share the signal.
+    from .models import VISION_SOURCES
+    has_gemini = float(bool(VISION_SOURCES.intersection(sources)))
     has_telemetry = float("telemetry" in sources)
     has_strava = float("strava" in sources)
     has_label = float("label" in sources)
+
 
     # Strava stars (from notes, if present)
     star_count = 0.0

--- a/src/gopro_garmin_pipeline/models/__init__.py
+++ b/src/gopro_garmin_pipeline/models/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .base import VISION_SOURCES, ModelAdapter
 from .gemini import GeminiAdapter
+from .local_vlm import LocalOpenAIAdapter
 from .openai import OpenAIAdapter
 
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     "ModelAdapter",
     "GeminiAdapter",
     "OpenAIAdapter",
+    "LocalOpenAIAdapter",
     "get_model_adapter",
     "provider_api_key",
     "cache_dir_name",
@@ -18,12 +20,21 @@ __all__ = [
 
 
 def provider_api_key(settings) -> str:
-    """Return the API key for the selected MODEL_PROVIDER (empty if unset)."""
+    """Return the API key for the selected MODEL_PROVIDER (empty if unset).
+
+    For ``local``, a truthy sentinel is returned only when both base URL and
+    model are configured — the scan/eval gates treat an empty string as
+    "skip this AI feature".
+    """
     provider = (settings.model_provider or "gemini").lower()
     if provider == "openai":
         return settings.openai_api_key or ""
     if provider == "gemini":
         return settings.gemini_api_key or ""
+    if provider == "local":
+        if settings.local_base_url and settings.local_model:
+            return settings.local_api_key or "local"
+        return ""
     return ""
 
 
@@ -36,7 +47,8 @@ def get_model_adapter(settings) -> ModelAdapter:
     """Construct a fresh adapter for the configured provider.
 
     Callers should create one adapter per clip / call site so nested
-    thread pools do not share a single client instance.
+    thread pools do not share a single client instance. The local adapter
+    still shares a process-wide request semaphore across instances.
     """
     provider = (settings.model_provider or "gemini").lower()
     if provider == "gemini":
@@ -49,6 +61,20 @@ def get_model_adapter(settings) -> ModelAdapter:
         if not key:
             raise ValueError("OPENAI_API_KEY is required when MODEL_PROVIDER=openai")
         return OpenAIAdapter(api_key=key, model=settings.openai_model)
+    if provider == "local":
+        model = (settings.local_model or "").strip()
+        if not model:
+            raise ValueError("LOCAL_MODEL is required when MODEL_PROVIDER=local")
+        base_url = (settings.local_base_url or "").strip()
+        if not base_url:
+            raise ValueError("LOCAL_BASE_URL is required when MODEL_PROVIDER=local")
+        return LocalOpenAIAdapter(
+            base_url=base_url,
+            api_key=settings.local_api_key or "local",
+            model=model,
+            max_concurrency=settings.local_max_concurrency,
+            timeout=settings.local_timeout_seconds,
+        )
     raise ValueError(
-        f"Unknown MODEL_PROVIDER={provider!r}; expected 'gemini' or 'openai'"
+        f"Unknown MODEL_PROVIDER={provider!r}; expected 'gemini', 'openai', or 'local'"
     )

--- a/src/gopro_garmin_pipeline/models/__init__.py
+++ b/src/gopro_garmin_pipeline/models/__init__.py
@@ -15,6 +15,7 @@ __all__ = [
     "LocalOpenAIAdapter",
     "get_model_adapter",
     "provider_api_key",
+    "provider_model_id",
     "cache_dir_name",
 ]
 
@@ -36,6 +37,20 @@ def provider_api_key(settings) -> str:
             return settings.local_api_key or "local"
         return ""
     return ""
+
+
+def provider_model_id(settings) -> str:
+    """Return the configured model id for the active provider."""
+    provider = (settings.model_provider or "gemini").lower()
+    if provider == "gemini":
+        return settings.gemini_model
+    if provider == "openai":
+        return settings.openai_model
+    if provider == "local":
+        return settings.local_model
+    raise ValueError(
+        f"Unknown MODEL_PROVIDER={provider!r}; expected 'gemini', 'openai', or 'local'"
+    )
 
 
 def cache_dir_name(provider: str) -> str:

--- a/src/gopro_garmin_pipeline/models/__init__.py
+++ b/src/gopro_garmin_pipeline/models/__init__.py
@@ -1,0 +1,54 @@
+"""Model provider adapters — one provider powers an entire pipeline run."""
+
+from __future__ import annotations
+
+from .base import VISION_SOURCES, ModelAdapter
+from .gemini import GeminiAdapter
+from .openai import OpenAIAdapter
+
+__all__ = [
+    "VISION_SOURCES",
+    "ModelAdapter",
+    "GeminiAdapter",
+    "OpenAIAdapter",
+    "get_model_adapter",
+    "provider_api_key",
+    "cache_dir_name",
+]
+
+
+def provider_api_key(settings) -> str:
+    """Return the API key for the selected MODEL_PROVIDER (empty if unset)."""
+    provider = (settings.model_provider or "gemini").lower()
+    if provider == "openai":
+        return settings.openai_api_key or ""
+    if provider == "gemini":
+        return settings.gemini_api_key or ""
+    return ""
+
+
+def cache_dir_name(provider: str) -> str:
+    """Per-provider cache directory name (e.g. .gemini_cache, .openai_cache)."""
+    return f".{provider}_cache"
+
+
+def get_model_adapter(settings) -> ModelAdapter:
+    """Construct a fresh adapter for the configured provider.
+
+    Callers should create one adapter per clip / call site so nested
+    thread pools do not share a single client instance.
+    """
+    provider = (settings.model_provider or "gemini").lower()
+    if provider == "gemini":
+        key = settings.gemini_api_key
+        if not key:
+            raise ValueError("GEMINI_API_KEY is required when MODEL_PROVIDER=gemini")
+        return GeminiAdapter(api_key=key, model=settings.gemini_model)
+    if provider == "openai":
+        key = settings.openai_api_key
+        if not key:
+            raise ValueError("OPENAI_API_KEY is required when MODEL_PROVIDER=openai")
+        return OpenAIAdapter(api_key=key, model=settings.openai_model)
+    raise ValueError(
+        f"Unknown MODEL_PROVIDER={provider!r}; expected 'gemini' or 'openai'"
+    )

--- a/src/gopro_garmin_pipeline/models/base.py
+++ b/src/gopro_garmin_pipeline/models/base.py
@@ -1,0 +1,102 @@
+"""Shared model-provider interface for vision scan and text JSON completion."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, Field
+
+
+VISION_SOURCES = frozenset({"gemini", "openai"})
+
+_REQUEST_TIMEOUT_S = 180.0
+
+
+# ─── Structured-output schemas (OpenAI; Gemini keeps free-form JSON) ───
+
+class FrameScore(BaseModel):
+    frame_index: int
+    visual: int = Field(ge=1, le=5)
+    action: int = Field(ge=1, le=5)
+    clip_type: str = ""
+    crop_x: int = Field(default=50, ge=0, le=100)
+    reason: str = ""
+
+
+class CoarseFrameBatch(BaseModel):
+    frames: list[FrameScore] = Field(default_factory=list)
+
+
+class ClipRubric(BaseModel):
+    light: int = Field(ge=1, le=10)
+    composition: int = Field(ge=1, le=10)
+    motion: int = Field(ge=1, le=10)
+    scenery: int = Field(ge=1, le=10)
+    subject: int = Field(ge=1, le=10)
+    peak_offset: float = Field(default=0.5, ge=0.0, le=1.0)
+    clip_type: str = ""
+    crop_x: int = Field(default=50, ge=0, le=100)
+    reason: str = ""
+
+
+class NarrativeIndices(BaseModel):
+    """Wrapper for narrative_select — OpenAI Structured Outputs need an object root."""
+
+    indices: list[int] = Field(default_factory=list)
+
+
+class PromptChange(BaseModel):
+    type: str = ""
+    section: str = ""
+    current_text: str = ""
+    suggested_text: str = ""
+    rationale: str = ""
+
+
+class ScoreAdjustments(BaseModel):
+    description: str = ""
+
+
+class PromptEvalResult(BaseModel):
+    """Schema matching prompts/eval JSON contract in prompt_eval._EVAL_TEMPLATE."""
+
+    analysis: str = ""
+    prompt_changes: list[PromptChange] = Field(default_factory=list)
+    suggested_score_adjustments: ScoreAdjustments = Field(
+        default_factory=ScoreAdjustments,
+    )
+
+
+@runtime_checkable
+class ModelAdapter(Protocol):
+    """One provider powers an entire run — vision scan and text JSON."""
+
+    name: str
+    model_id: str
+
+    def score_frames(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> list[dict]:
+        """Coarse pass: score N frames. Returns list of frame dicts."""
+        ...
+
+    def score_clip_rubric(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> dict | None:
+        """Fine pass: rate one clip on the 5-dim rubric."""
+        ...
+
+    def complete_json(
+        self,
+        *,
+        prompt: str,
+        system: str | None = None,
+        temperature: float = 0.3,
+        max_output_tokens: int = 1024,
+    ) -> dict | list:
+        """Text-only JSON completion (narrative select, prompt eval)."""
+        ...
+
+    def is_transient_error(self, exc: BaseException) -> bool:
+        """True if the exception is worth retrying with backoff."""
+        ...

--- a/src/gopro_garmin_pipeline/models/base.py
+++ b/src/gopro_garmin_pipeline/models/base.py
@@ -7,7 +7,7 @@ from typing import Protocol, runtime_checkable
 from pydantic import BaseModel, Field
 
 
-VISION_SOURCES = frozenset({"gemini", "openai"})
+VISION_SOURCES = frozenset({"gemini", "openai", "local"})
 
 _REQUEST_TIMEOUT_S = 180.0
 

--- a/src/gopro_garmin_pipeline/models/gemini.py
+++ b/src/gopro_garmin_pipeline/models/gemini.py
@@ -1,0 +1,104 @@
+"""Gemini implementation of ModelAdapter."""
+
+from __future__ import annotations
+
+from ..utils import parse_json_response
+from .base import _REQUEST_TIMEOUT_S
+
+
+class GeminiAdapter:
+    """google-genai backed adapter. Behavior matches the pre-adapter call sites."""
+
+    name = "gemini"
+
+    def __init__(self, *, api_key: str, model: str) -> None:
+        self.model_id = model
+        from google import genai
+        self._client = genai.Client(api_key=api_key)
+
+    def score_frames(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> list[dict]:
+        from google.genai import types
+
+        parts = [
+            types.Part.from_bytes(data=img, mime_type="image/jpeg")
+            for img in images
+        ]
+        parts.append(types.Part.from_text(text=user))
+
+        response = self._client.models.generate_content(
+            model=self.model_id,
+            contents=[types.Content(parts=parts)],
+            config=types.GenerateContentConfig(
+                system_instruction=system,
+                http_options=types.HttpOptions(
+                    timeout=int(_REQUEST_TIMEOUT_S * 1000),
+                ),
+            ),
+        )
+        result = parse_json_response(response.text)
+        return result if isinstance(result, list) else []
+
+    def score_clip_rubric(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> dict | None:
+        from google.genai import types
+
+        parts = [
+            types.Part.from_bytes(data=img, mime_type="image/jpeg")
+            for img in images
+        ]
+        parts.append(types.Part.from_text(text=user))
+
+        response = self._client.models.generate_content(
+            model=self.model_id,
+            contents=[types.Content(parts=parts)],
+            config=types.GenerateContentConfig(
+                system_instruction=system,
+                http_options=types.HttpOptions(
+                    timeout=int(_REQUEST_TIMEOUT_S * 1000),
+                ),
+            ),
+        )
+        result = parse_json_response(response.text)
+        if isinstance(result, dict):
+            return result
+        if isinstance(result, list) and result:
+            first = result[0]
+            return first if isinstance(first, dict) else None
+        return None
+
+    def complete_json(
+        self,
+        *,
+        prompt: str,
+        system: str | None = None,
+        temperature: float = 0.3,
+        max_output_tokens: int = 1024,
+    ) -> dict | list:
+        from google.genai import types
+
+        config_kwargs: dict = {
+            "temperature": temperature,
+            "max_output_tokens": max_output_tokens,
+        }
+        if system:
+            # prompt_eval path — system instruction, no thinking budget
+            config_kwargs["system_instruction"] = system
+        else:
+            # narrative_select path — thinking budget, no system instruction
+            config_kwargs["thinking_config"] = types.ThinkingConfig(
+                thinking_budget=256,
+            )
+
+        response = self._client.models.generate_content(
+            model=self.model_id,
+            contents=[types.Content(parts=[types.Part.from_text(text=prompt)])],
+            config=types.GenerateContentConfig(**config_kwargs),
+        )
+        return parse_json_response(response.text)
+
+    def is_transient_error(self, exc: BaseException) -> bool:
+        msg = str(exc)
+        return any(code in msg for code in ("503", "429", "UNAVAILABLE"))

--- a/src/gopro_garmin_pipeline/models/local_vlm.py
+++ b/src/gopro_garmin_pipeline/models/local_vlm.py
@@ -1,0 +1,462 @@
+"""Local OpenAI-compatible VLM adapter (MLX-VLM, Ollama, LM Studio, vLLM).
+
+Uses Chat Completions with json_schema structured outputs when the server
+supports them (MLX-VLM). Falls back once to free-form JSON parsing for less
+capable servers. A process-wide semaphore caps concurrent requests because
+the scanner constructs a fresh adapter per clip.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import threading
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from ..utils import parse_json_response
+from .base import (
+    ClipRubric,
+    CoarseFrameBatch,
+    NarrativeIndices,
+    PromptEvalResult,
+)
+
+T = TypeVar("T", bound=BaseModel)
+
+# Process-wide: each clip builds its own adapter, so a per-instance
+# semaphore cannot throttle the scanner's nested thread pools.
+_LOCAL_REQUEST_SEMAPHORE: threading.Semaphore | None = None
+_LOCAL_SEMAPHORE_LIMIT: int | None = None
+_LOCAL_SEMAPHORE_LOCK = threading.Lock()
+
+_DEFAULT_MAX_CONCURRENCY = 1
+_DEFAULT_TIMEOUT_S = 600.0
+
+
+def _get_local_request_semaphore(max_concurrency: int) -> threading.Semaphore:
+    """Return the shared request semaphore, initializing it on first use."""
+    global _LOCAL_REQUEST_SEMAPHORE, _LOCAL_SEMAPHORE_LIMIT
+    with _LOCAL_SEMAPHORE_LOCK:
+        if _LOCAL_REQUEST_SEMAPHORE is None:
+            limit = max(1, int(max_concurrency))
+            _LOCAL_REQUEST_SEMAPHORE = threading.Semaphore(limit)
+            _LOCAL_SEMAPHORE_LIMIT = limit
+        return _LOCAL_REQUEST_SEMAPHORE
+
+
+def _reset_local_request_semaphore_for_tests() -> None:
+    """Clear the process-wide semaphore (tests only)."""
+    global _LOCAL_REQUEST_SEMAPHORE, _LOCAL_SEMAPHORE_LIMIT
+    with _LOCAL_SEMAPHORE_LOCK:
+        _LOCAL_REQUEST_SEMAPHORE = None
+        _LOCAL_SEMAPHORE_LIMIT = None
+
+
+def _response_format_for(model: type[BaseModel], name: str) -> dict:
+    return {
+        "type": "json_schema",
+        "json_schema": {
+            "name": name,
+            "strict": True,
+            "schema": model.model_json_schema(),
+        },
+    }
+
+
+def _is_structured_format_rejected(exc: BaseException) -> bool:
+    """True when the server rejected response_format / json_schema."""
+    status = getattr(exc, "status_code", None)
+    msg = str(exc).lower()
+    markers = (
+        "response_format",
+        "json_schema",
+        "structured output",
+        "structured_output",
+        "unsupported",
+        "invalid_request",
+        "unknown parameter",
+        "extra inputs are not permitted",
+    )
+    if any(m in msg for m in markers):
+        # Auth / missing model must not trigger free-form fallback.
+        if any(bad in msg for bad in ("api key", "unauthorized", "authentication", "model not found", "does not exist")):
+            return False
+        if status is None or status == 400 or status == 422:
+            return True
+    return False
+
+
+def _is_connection_failure(exc: BaseException) -> bool:
+    """True when the local server is unreachable (do not retry / backoff)."""
+    try:
+        from openai import APIConnectionError
+    except ImportError:
+        APIConnectionError = ()  # type: ignore[misc,assignment]
+
+    if isinstance(exc, APIConnectionError):
+        return True
+
+    msg = str(exc).lower()
+    return any(
+        s in msg
+        for s in (
+            "connection refused",
+            "failed to connect",
+            "connect error",
+            "connection error",
+            "nodename nor servname",
+            "name or service not known",
+            "network is unreachable",
+            "no route to host",
+        )
+    )
+
+
+def _is_permanent_configuration_error(exc: BaseException) -> bool:
+    """True when retrying cannot fix the local server/model configuration."""
+    status = getattr(exc, "status_code", None)
+    msg = str(exc).lower()
+    markers = (
+        "failed to load model",
+        "model not found",
+        "model does not exist",
+        "invalid model",
+        "invalid repo id",
+        "repo id must use",
+        "repository not found",
+    )
+    return status == 404 or any(marker in msg for marker in markers)
+
+
+class LocalOpenAIAdapter:
+    """Chat Completions adapter for local OpenAI-compatible VLM servers."""
+
+    name = "local"
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        model: str,
+        max_concurrency: int = _DEFAULT_MAX_CONCURRENCY,
+        timeout: float = _DEFAULT_TIMEOUT_S,
+    ) -> None:
+        self.model_id = model
+        self.base_url = base_url.rstrip("/")
+        self._timeout = float(timeout)
+        self._semaphore = _get_local_request_semaphore(max_concurrency)
+        from openai import OpenAI
+        self._client = OpenAI(
+            api_key=api_key or "local",
+            base_url=self.base_url,
+            timeout=self._timeout,
+        )
+
+    def _image_content(self, images: list[bytes], user: str) -> list[dict]:
+        content: list[dict] = []
+        for img in images:
+            b64 = base64.b64encode(img).decode("ascii")
+            content.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:image/jpeg;base64,{b64}"},
+            })
+        content.append({"type": "text", "text": user})
+        return content
+
+    def _messages(
+        self,
+        *,
+        system: str | None,
+        user_content: str | list[dict],
+    ) -> list[dict]:
+        messages: list[dict] = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": user_content})
+        return messages
+
+    def _create(
+        self,
+        *,
+        messages: list[dict],
+        response_format: dict | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> Any:
+        kwargs: dict[str, Any] = {
+            "model": self.model_id,
+            "messages": messages,
+        }
+        if response_format is not None:
+            kwargs["response_format"] = response_format
+        if temperature is not None:
+            kwargs["temperature"] = temperature
+        if max_tokens is not None:
+            kwargs["max_tokens"] = max_tokens
+
+        with self._semaphore:
+            try:
+                return self._client.chat.completions.create(**kwargs)
+            except Exception as exc:
+                if _is_connection_failure(exc):
+                    raise ConnectionError(
+                        f"Local VLM unreachable at {self.base_url} — "
+                        "is the server running?"
+                    ) from exc
+                raise
+
+    def _message_text(self, response: Any) -> str:
+        try:
+            content = response.choices[0].message.content
+        except (AttributeError, IndexError, TypeError) as exc:
+            raise ValueError("Local VLM returned no message content") from exc
+        if not content or not str(content).strip():
+            raise ValueError("Local VLM returned empty message content")
+        return str(content)
+
+    def _complete_structured(
+        self,
+        *,
+        messages: list[dict],
+        schema: type[T],
+        schema_name: str,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+    ) -> T:
+        fmt = _response_format_for(schema, schema_name)
+        try:
+            response = self._create(
+                messages=messages,
+                response_format=fmt,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+        except Exception as exc:
+            if not _is_structured_format_rejected(exc):
+                raise
+            response = self._create(
+                messages=messages,
+                response_format=None,
+                temperature=temperature,
+                max_tokens=max_tokens,
+            )
+            return self._parse_freeform_as(schema, self._message_text(response))
+
+        text = self._message_text(response)
+        try:
+            return schema.model_validate_json(text)
+        except (ValidationError, json.JSONDecodeError):
+            # Some servers honor response_format loosely; validate via free-form
+            # parse only if the text is still the right shape.
+            return self._parse_freeform_as(schema, text)
+
+    @staticmethod
+    def _parse_json_or_raise(text: str) -> dict | list:
+        """Parse model text as JSON; never silently return an empty sentinel."""
+        cleaned = re.sub(r"```(?:json)?\s*", "", text)
+        cleaned = re.sub(r"```\s*$", "", cleaned).strip()
+        try:
+            result = json.loads(cleaned)
+            if isinstance(result, (dict, list)):
+                return result
+            raise ValueError(
+                f"Local VLM returned JSON {type(result).__name__}, "
+                "expected object or array"
+            )
+        except json.JSONDecodeError:
+            pass
+
+        parsed = parse_json_response(text)
+        # parse_json_response returns {} / [] on failure — reject those
+        # sentinels unless the cleaned text is literally an empty container.
+        if parsed == {} and cleaned not in ("{}",):
+            raise ValueError("Local VLM returned unparseable JSON")
+        if parsed == [] and cleaned not in ("[]",):
+            raise ValueError("Local VLM returned unparseable JSON")
+        if not isinstance(parsed, (dict, list)):
+            raise ValueError("Local VLM returned unparseable JSON")
+        return parsed
+
+    def _parse_freeform_as(self, schema: type[T], text: str) -> T:
+        parsed = self._parse_json_or_raise(text)
+        if schema is CoarseFrameBatch:
+            if isinstance(parsed, list):
+                try:
+                    return schema.model_validate({"frames": parsed})  # type: ignore[return-value]
+                except ValidationError as exc:
+                    raise ValueError(
+                        "Local VLM coarse pass returned invalid frame list"
+                    ) from exc
+            if isinstance(parsed, dict) and "frames" in parsed:
+                try:
+                    return schema.model_validate(parsed)  # type: ignore[return-value]
+                except ValidationError as exc:
+                    raise ValueError(
+                        "Local VLM coarse pass returned invalid frames object"
+                    ) from exc
+            raise ValueError(
+                "Local VLM coarse pass expected a JSON array of frames "
+                f"(got {type(parsed).__name__})"
+            )
+
+        if schema is NarrativeIndices:
+            if isinstance(parsed, list):
+                if not all(isinstance(x, int) and not isinstance(x, bool) for x in parsed):
+                    raise ValueError(
+                        "Local VLM narrative select expected a JSON array of ints"
+                    )
+                return schema.model_validate({"indices": parsed})  # type: ignore[return-value]
+            if isinstance(parsed, dict) and "indices" in parsed:
+                try:
+                    return schema.model_validate(parsed)  # type: ignore[return-value]
+                except ValidationError as exc:
+                    raise ValueError(
+                        "Local VLM narrative select returned invalid indices"
+                    ) from exc
+            raise ValueError(
+                "Local VLM narrative select expected a JSON array of indices "
+                f"(got {type(parsed).__name__})"
+            )
+
+        if schema is ClipRubric:
+            if isinstance(parsed, list):
+                if not parsed or not isinstance(parsed[0], dict):
+                    raise ValueError(
+                        "Local VLM fine pass expected a rubric object "
+                        "(got empty or non-object list)"
+                    )
+                parsed = parsed[0]
+            if not isinstance(parsed, dict):
+                raise ValueError(
+                    "Local VLM fine pass expected a JSON object "
+                    f"(got {type(parsed).__name__})"
+                )
+            try:
+                return schema.model_validate(parsed)  # type: ignore[return-value]
+            except ValidationError as exc:
+                raise ValueError(
+                    "Local VLM fine pass returned invalid rubric object"
+                ) from exc
+
+        # PromptEvalResult and other object schemas
+        if not isinstance(parsed, dict):
+            raise ValueError(
+                f"Local VLM expected a JSON object (got {type(parsed).__name__})"
+            )
+        try:
+            return schema.model_validate(parsed)  # type: ignore[return-value]
+        except ValidationError as exc:
+            raise ValueError(
+                f"Local VLM returned JSON that does not match {schema.__name__}"
+            ) from exc
+
+    def score_frames(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> list[dict]:
+        # Structured Outputs need an object root; wrap the bare array.
+        system_wrapped = (
+            f"{system}\n\n"
+            "Return a JSON object with key \"frames\" whose value is the "
+            "JSON array described above (empty array if nothing qualifies)."
+        )
+        messages = self._messages(
+            system=system_wrapped,
+            user_content=self._image_content(images, user),
+        )
+        parsed = self._complete_structured(
+            messages=messages,
+            schema=CoarseFrameBatch,
+            schema_name="coarse_frame_batch",
+        )
+        return [f.model_dump() for f in parsed.frames]
+
+    def score_clip_rubric(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> dict | None:
+        messages = self._messages(
+            system=system,
+            user_content=self._image_content(images, user),
+        )
+        parsed = self._complete_structured(
+            messages=messages,
+            schema=ClipRubric,
+            schema_name="clip_rubric",
+        )
+        return parsed.model_dump()
+
+    def complete_json(
+        self,
+        *,
+        prompt: str,
+        system: str | None = None,
+        temperature: float = 0.3,
+        max_output_tokens: int = 1024,
+    ) -> dict | list:
+        if system:
+            instructions = (
+                f"{system.rstrip()}\n\n"
+                "Respond with a JSON object matching the requested schema "
+                "(analysis, prompt_changes, suggested_score_adjustments)."
+            )
+            messages = self._messages(system=instructions, user_content=prompt)
+            parsed = self._complete_structured(
+                messages=messages,
+                schema=PromptEvalResult,
+                schema_name="prompt_eval_result",
+                temperature=temperature,
+                max_tokens=max_output_tokens,
+            )
+            return parsed.model_dump()
+
+        instructions = (
+            "Select clip indices as instructed. Respond with a JSON object "
+            "{\"indices\": [<int>, ...]} — a flat array of candidate indices "
+            "in narrative order (empty array if none)."
+        )
+        messages = self._messages(system=instructions, user_content=prompt)
+        parsed = self._complete_structured(
+            messages=messages,
+            schema=NarrativeIndices,
+            schema_name="narrative_indices",
+            temperature=temperature,
+            max_tokens=max_output_tokens,
+        )
+        return list(parsed.indices)
+
+    def is_transient_error(self, exc: BaseException) -> bool:
+        # Connection refusal / unreachable host: fail fast — backoff wastes
+        # ~155s per request when the local server is simply not running.
+        if isinstance(exc, ConnectionError) or _is_connection_failure(exc):
+            return False
+
+        # MLX-VLM reports invalid model ids as HTTP 500 after attempting a
+        # lazy model swap. Retrying only repeats the same expensive load and
+        # obscures the actionable configuration error.
+        if _is_permanent_configuration_error(exc):
+            return False
+
+        try:
+            from openai import (
+                APITimeoutError,
+                InternalServerError,
+                RateLimitError,
+            )
+        except ImportError:
+            RateLimitError = APITimeoutError = InternalServerError = ()  # type: ignore[misc,assignment]
+
+        if isinstance(exc, (RateLimitError, APITimeoutError, InternalServerError)):
+            return True
+
+        status = getattr(exc, "status_code", None)
+        if isinstance(status, int) and (status == 429 or status >= 500):
+            return True
+
+        msg = str(exc).lower()
+        return any(
+            code in msg
+            for code in ("429", "500", "502", "503", "504", "timeout")
+        )

--- a/src/gopro_garmin_pipeline/models/openai.py
+++ b/src/gopro_garmin_pipeline/models/openai.py
@@ -1,0 +1,138 @@
+"""OpenAI Responses API implementation of ModelAdapter."""
+
+from __future__ import annotations
+
+import base64
+
+from .base import (
+    ClipRubric,
+    CoarseFrameBatch,
+    NarrativeIndices,
+    PromptEvalResult,
+    _REQUEST_TIMEOUT_S,
+)
+
+
+class OpenAIAdapter:
+    """openai Responses API adapter with Structured Outputs for all passes."""
+
+    name = "openai"
+
+    def __init__(self, *, api_key: str, model: str) -> None:
+        self.model_id = model
+        from openai import OpenAI
+        self._client = OpenAI(api_key=api_key, timeout=_REQUEST_TIMEOUT_S)
+
+    def _image_input(self, images: list[bytes], user: str) -> list[dict]:
+        content: list[dict] = []
+        for img in images:
+            b64 = base64.b64encode(img).decode("ascii")
+            content.append({
+                "type": "input_image",
+                "image_url": f"data:image/jpeg;base64,{b64}",
+            })
+        content.append({"type": "input_text", "text": user})
+        return content
+
+    def score_frames(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> list[dict]:
+        # Prompt asks for a bare array; Structured Outputs need an object root.
+        system_wrapped = (
+            f"{system}\n\n"
+            "Return a JSON object with key \"frames\" whose value is the "
+            "JSON array described above (empty array if nothing qualifies)."
+        )
+        response = self._client.responses.parse(
+            model=self.model_id,
+            instructions=system_wrapped,
+            input=[{"role": "user", "content": self._image_input(images, user)}],
+            text_format=CoarseFrameBatch,
+        )
+        parsed = response.output_parsed
+        if parsed is None:
+            raise ValueError("OpenAI coarse pass returned no structured output")
+        return [f.model_dump() for f in parsed.frames]
+
+    def score_clip_rubric(
+        self, *, images: list[bytes], system: str, user: str,
+    ) -> dict | None:
+        response = self._client.responses.parse(
+            model=self.model_id,
+            instructions=system,
+            input=[{"role": "user", "content": self._image_input(images, user)}],
+            text_format=ClipRubric,
+        )
+        parsed = response.output_parsed
+        if parsed is None:
+            # Must raise — returning None is treated as a normal empty rubric
+            # and can be cached permanently as "scanned, found nothing."
+            raise ValueError("OpenAI fine pass returned no structured output")
+        return parsed.model_dump()
+
+    def complete_json(
+        self,
+        *,
+        prompt: str,
+        system: str | None = None,
+        temperature: float = 0.3,
+        max_output_tokens: int = 1024,
+    ) -> dict | list:
+        # system set → prompt_eval object; otherwise narrative index list.
+        if system:
+            instructions = (
+                f"{system.rstrip()}\n\n"
+                "Respond with a JSON object matching the requested schema "
+                "(analysis, prompt_changes, suggested_score_adjustments)."
+            )
+            response = self._client.responses.parse(
+                model=self.model_id,
+                instructions=instructions,
+                input=prompt,
+                temperature=temperature,
+                max_output_tokens=max_output_tokens,
+                text_format=PromptEvalResult,
+            )
+            parsed = response.output_parsed
+            if parsed is None:
+                raise ValueError("OpenAI prompt-eval returned no structured output")
+            return parsed.model_dump()
+
+        instructions = (
+            "Select clip indices as instructed. Respond with a JSON object "
+            "{\"indices\": [<int>, ...]} — a flat array of candidate indices "
+            "in narrative order (empty array if none)."
+        )
+        response = self._client.responses.parse(
+            model=self.model_id,
+            instructions=instructions,
+            input=prompt,
+            temperature=temperature,
+            max_output_tokens=max_output_tokens,
+            text_format=NarrativeIndices,
+        )
+        parsed = response.output_parsed
+        if parsed is None:
+            raise ValueError("OpenAI narrative select returned no structured output")
+        return list(parsed.indices)
+
+    def is_transient_error(self, exc: BaseException) -> bool:
+        try:
+            from openai import (
+                APIConnectionError,
+                APITimeoutError,
+                InternalServerError,
+                RateLimitError,
+            )
+        except ImportError:
+            RateLimitError = APITimeoutError = APIConnectionError = InternalServerError = ()  # type: ignore[misc,assignment]
+
+        if isinstance(exc, (RateLimitError, APITimeoutError, APIConnectionError, InternalServerError)):
+            return True
+
+        status = getattr(exc, "status_code", None)
+        if isinstance(status, int) and (status == 429 or status >= 500):
+            return True
+
+        msg = str(exc)
+        return any(code in msg for code in ("429", "500", "502", "503", "504", "timeout", "Timeout"))

--- a/src/gopro_garmin_pipeline/prompt_eval.py
+++ b/src/gopro_garmin_pipeline/prompt_eval.py
@@ -60,12 +60,9 @@ def _active_provider(settings) -> str:
 
 
 def _active_model_id(settings) -> str:
-    provider = _active_provider(settings)
-    if provider == "openai":
-        return settings.openai_model
-    if provider == "local":
-        return settings.local_model
-    return settings.gemini_model
+    from .models import provider_model_id
+
+    return provider_model_id(settings)
 
 
 def _sanitize_model_id(model_id: str) -> str:
@@ -375,14 +372,18 @@ def _cache_files_for_active_model(cache_dir: Path, provider: str, model_id: str)
     return matched
 
 
-def _load_model_hits(date_folder: Path) -> list[dict]:
+def _load_model_hits(
+    date_folder: Path,
+    chapter_names: set[str] | None = None,
+) -> list[dict]:
     """Load vision-scan hits from the active provider's cache directory.
 
     Uses ``MODEL_PROVIDER`` to pick ``.{provider}_cache/``. Does **not**
     fall back across providers (one-provider rule). Gemini still accepts
     legacy ``gemini_cache.json``. OpenAI files are filtered to the active
-    ``OPENAI_MODEL`` fingerprint. When local ``*.MP4``/``*.mp4`` files
-    exist, hits for other chapters are dropped.
+    ``OPENAI_MODEL`` fingerprint. Hits are restricted to *chapter_names*
+    when supplied; otherwise local ``*.MP4``/``*.mp4`` files define the
+    restriction when present.
     """
     from .config import get_settings
     from .models import cache_dir_name
@@ -398,9 +399,12 @@ def _load_model_hits(date_folder: Path) -> list[dict]:
             if legacy.exists():
                 hits = json.loads(legacy.read_text())
                 if isinstance(hits, list):
-                    return _filter_hits_to_local_chapters(
-                        hits, _local_chapter_names(date_folder),
+                    names = (
+                        chapter_names
+                        if chapter_names is not None
+                        else _local_chapter_names(date_folder)
                     )
+                    return _filter_hits_to_local_chapters(hits, names)
         return []
 
     all_hits = []
@@ -411,7 +415,12 @@ def _load_model_hits(date_folder: Path) -> list[dict]:
                 all_hits.extend(hits)
         except (json.JSONDecodeError, OSError):
             continue
-    return _filter_hits_to_local_chapters(all_hits, _local_chapter_names(date_folder))
+    names = (
+        chapter_names
+        if chapter_names is not None
+        else _local_chapter_names(date_folder)
+    )
+    return _filter_hits_to_local_chapters(all_hits, names)
 
 
 # Thin alias for callers/tests that still use the old name
@@ -595,9 +604,18 @@ def compare_ride(date_folder: Path) -> CompareReport:
     provider = _active_provider(settings)
     model_id = _active_model_id(settings)
 
+    all_labels = _load_labels(date_folder)
     local_names = _local_chapter_names(date_folder)
-    labels = _filter_labels_to_local_chapters(_load_labels(date_folder), local_names)
-    model_hits = _load_model_hits(date_folder)
+    # The committed sample contains no MP4s. In that case its labeled chapter
+    # names define the comparison tier, preventing the 19-chapter Gemini
+    # baseline from being compared against eight chapters of alternatives.
+    comparison_names = local_names or {
+        str(label.get("clip_name", ""))
+        for label in all_labels
+        if label.get("clip_name")
+    }
+    labels = _filter_labels_to_local_chapters(all_labels, comparison_names)
+    model_hits = _load_model_hits(date_folder, comparison_names)
 
     if not labels:
         print(f"No labels found in {date_folder}")

--- a/src/gopro_garmin_pipeline/prompt_eval.py
+++ b/src/gopro_garmin_pipeline/prompt_eval.py
@@ -1,13 +1,13 @@
-"""Compare human labels vs Gemini scan output and drive prompt improvement.
+"""Compare human labels vs vision-model scan output and drive prompt improvement.
 
 Two workflows:
 
-1. **compare**: Load labels + Gemini cache for a ride, align temporally,
-   categorize as matched / label-only (Gemini missed) / gemini-only.
+1. **compare**: Load labels + provider cache for a ride, align temporally,
+   categorize as matched / label-only (model missed) / model-only.
    Outputs a structured JSON report + human-readable summary.
 
-2. **eval-prompt**: Feed the comparison report to Gemini and ask it to
-   analyze systematic patterns and suggest prompt improvements.
+2. **eval-prompt**: Feed the comparison report to the active MODEL_PROVIDER
+   and ask it to analyze systematic patterns and suggest prompt improvements.
    Accumulates across rides for cross-ride analysis.
 
 Usage:
@@ -18,18 +18,33 @@ Usage:
 
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
 from .utils import format_time, normalize_label_scale, rating_visual_action
 
-# Temporal alignment window: label and Gemini hit within this many
+# Temporal alignment window: label and model hit within this many
 # seconds are considered a "match"
 _MATCH_WINDOW = 15.0
 
-# Report filename
-_REPORT_NAME = "prompt_eval.json"
+# Legacy filename (implicitly Gemini); only used when MODEL_PROVIDER=gemini
+_LEGACY_REPORT_NAME = "prompt_eval.json"
+
+_HIT_FIELD_MAP = {
+    "gemini_visual": "model_visual",
+    "gemini_action": "model_action",
+    "gemini_clip_type": "model_clip_type",
+    "gemini_reason": "model_reason",
+}
+
+_PATTERN_KEY_MAP = {
+    "gemini_misses_by_type": "model_misses_by_type",
+    "gemini_overflag_by_clip_type": "model_overflag_by_clip_type",
+    "avg_gemini_only_scores": "avg_model_only_scores",
+}
 
 
 def _hit_video_secs(hit: dict) -> float:
@@ -40,20 +55,167 @@ def _hit_video_secs(hit: dict) -> float:
     return v or 0.0
 
 
+def _active_provider(settings) -> str:
+    return (settings.model_provider or "gemini").lower()
+
+
+def _active_model_id(settings) -> str:
+    provider = _active_provider(settings)
+    if provider == "openai":
+        return settings.openai_model
+    return settings.gemini_model
+
+
+def _sanitize_model_id(model_id: str) -> str:
+    """Make a model id safe for use as a filename component.
+
+    Keeps alphanumerics, dots, hyphens, underscores; maps everything else
+    to ``-`` and collapses runs so unusual IDs cannot escape the folder
+    or collide via path separators / spaces.
+
+    When sanitization changes the id (e.g. ``org/model:v1`` → ``org-model-v1``),
+    append a short stable hash of the original so distinct raw ids cannot
+    overwrite each other's reports.
+    """
+    raw = (model_id or "unknown").strip()
+    s = re.sub(r"[^A-Za-z0-9._-]+", "-", raw)
+    s = re.sub(r"-{2,}", "-", s).strip("-.")
+    s = s or "unknown"
+    if s != raw:
+        fp = hashlib.sha1(raw.encode()).hexdigest()[:8]
+        return f"{s}_{fp}"
+    return s
+
+
+def _report_filename(provider: str, model_id: str) -> str:
+    return f"prompt_eval_{provider}_{_sanitize_model_id(model_id)}.json"
+
+
+def _suggestions_filename(provider: str, model_id: str) -> str:
+    return f"prompt_eval_suggestions_{provider}_{_sanitize_model_id(model_id)}.json"
+
+
+def _local_chapter_names(date_folder: Path) -> set[str]:
+    """Basenames of locally present GoPro chapter files (no ffprobe)."""
+    names = {p.name for p in date_folder.glob("*.MP4")}
+    names |= {p.name for p in date_folder.glob("*.mp4")}
+    return names
+
+
+def _filter_hits_to_local_chapters(
+    hits: list[dict], local_names: set[str],
+) -> list[dict]:
+    """Drop hits whose clip_name is not among locally present chapters.
+
+    When *local_names* is empty (sidecar-only), returns *hits* unchanged.
+    """
+    if not local_names:
+        return hits
+    return [h for h in hits if h.get("clip_name", "") in local_names]
+
+
+def _filter_labels_to_local_chapters(
+    labels: list[dict], local_names: set[str],
+) -> list[dict]:
+    """Drop labels whose non-empty clip_name is known absent locally.
+
+    Labels with missing/empty ``clip_name`` are retained (legacy).
+    When *local_names* is empty, returns *labels* unchanged.
+    """
+    if not local_names:
+        return labels
+    kept = []
+    for lab in labels:
+        clip = lab.get("clip_name") or ""
+        if not clip or clip in local_names:
+            kept.append(lab)
+    return kept
+
+
+def _normalize_hit(hit: dict) -> dict:
+    """Map legacy gemini_* hit keys to model_*."""
+    out = dict(hit)
+    for old, new in _HIT_FIELD_MAP.items():
+        if new not in out and old in out:
+            out[new] = out.pop(old)
+        elif old in out:
+            out.pop(old)
+    return out
+
+
+def _normalize_patterns(patterns: dict) -> dict:
+    if not patterns:
+        return {}
+    out = {}
+    for k, v in patterns.items():
+        out[_PATTERN_KEY_MAP.get(k, k)] = v
+    return out
+
+
+def _normalize_report(report: dict) -> dict:
+    """Map legacy gemini_* report schema to model_* before aggregation.
+
+    Call on every report read. Downstream only reads model_* keys.
+    """
+    r = dict(report)
+    summary = dict(r.get("summary") or {})
+    if "n_model_hits" not in summary and "n_gemini_hits" in summary:
+        summary["n_model_hits"] = summary.pop("n_gemini_hits")
+    elif "n_gemini_hits" in summary:
+        summary.pop("n_gemini_hits")
+    if "n_model_only" not in summary and "n_gemini_only" in summary:
+        summary["n_model_only"] = summary.pop("n_gemini_only")
+    elif "n_gemini_only" in summary:
+        summary.pop("n_gemini_only")
+    # Legacy unidentified reports are implicitly Gemini
+    if "provider" not in summary and "provider" not in r:
+        summary.setdefault("provider", "gemini")
+    r["summary"] = summary
+
+    if "model_only" not in r and "gemini_only" in r:
+        r["model_only"] = r.pop("gemini_only")
+    elif "gemini_only" in r:
+        r.pop("gemini_only")
+
+    for key in ("matched", "label_only", "model_only"):
+        items = r.get(key)
+        if isinstance(items, list):
+            r[key] = [_normalize_hit(h) if isinstance(h, dict) else h for h in items]
+
+    r["patterns"] = _normalize_patterns(r.get("patterns") or {})
+    return r
+
+
+def _resolve_report_path(date_folder: Path, provider: str, model_id: str) -> Path | None:
+    """Return the report path to load for provider/model, or None.
+
+    Prefers the scoped filename. Falls back to legacy ``prompt_eval.json``
+    only when *provider* is ``gemini`` (legacy files are implicitly Gemini).
+    """
+    scoped = date_folder / _report_filename(provider, model_id)
+    if scoped.exists():
+        return scoped
+    if provider == "gemini":
+        legacy = date_folder / _LEGACY_REPORT_NAME
+        if legacy.exists():
+            return legacy
+    return None
+
+
 @dataclass
 class CompareHit:
-    """A single moment from either labels or Gemini, with match info."""
+    """A single moment from either labels or the vision model, with match info."""
 
     ride_time_secs: float
-    source: str  # "label", "gemini", or "both"
+    source: str  # "label", provider id, or "both"
     label_type: str = ""
     label_notes: str = ""
     label_visual: int = 0
     label_action: int = 0
-    gemini_visual: int = 0
-    gemini_action: int = 0
-    gemini_clip_type: str = ""
-    gemini_reason: str = ""
+    model_visual: int = 0
+    model_action: int = 0
+    model_clip_type: str = ""
+    model_reason: str = ""
     clip_name: str = ""
     video_secs: float = 0.0
 
@@ -73,38 +235,40 @@ class CompareHit:
             d["label_action"] = self.label_action
         if self.label_notes:
             d["label_notes"] = self.label_notes
-        if self.gemini_visual:
-            d["gemini_visual"] = self.gemini_visual
-        if self.gemini_action:
-            d["gemini_action"] = self.gemini_action
-        if self.gemini_clip_type:
-            d["gemini_clip_type"] = self.gemini_clip_type
-        if self.gemini_reason:
-            d["gemini_reason"] = self.gemini_reason
+        if self.model_visual:
+            d["model_visual"] = self.model_visual
+        if self.model_action:
+            d["model_action"] = self.model_action
+        if self.model_clip_type:
+            d["model_clip_type"] = self.model_clip_type
+        if self.model_reason:
+            d["model_reason"] = self.model_reason
         return d
 
 
 @dataclass
 class CompareReport:
-    """Structured comparison of labels vs Gemini scan for one ride."""
+    """Structured comparison of labels vs vision-model scan for one ride."""
 
     date_folder: str
+    provider: str = "gemini"
+    model: str = ""
     n_labels: int = 0
-    n_gemini_hits: int = 0
+    n_model_hits: int = 0
     matched: list[CompareHit] = field(default_factory=list)
-    label_only: list[CompareHit] = field(default_factory=list)  # Gemini missed
-    gemini_only: list[CompareHit] = field(default_factory=list)  # user didn't flag
+    label_only: list[CompareHit] = field(default_factory=list)  # model missed
+    model_only: list[CompareHit] = field(default_factory=list)  # user didn't flag
     patterns: dict = field(default_factory=dict)  # systematic observations
 
     @property
     def precision(self) -> float:
-        """Of Gemini's hits, what fraction did the user also flag?"""
-        total = len(self.matched) + len(self.gemini_only)
+        """Of the model's hits, what fraction did the user also flag?"""
+        total = len(self.matched) + len(self.model_only)
         return len(self.matched) / total if total else 0.0
 
     @property
     def recall(self) -> float:
-        """Of user's labels, what fraction did Gemini also find?"""
+        """Of user's labels, what fraction did the model also find?"""
         total = len(self.matched) + len(self.label_only)
         return len(self.matched) / total if total else 0.0
 
@@ -112,47 +276,53 @@ class CompareReport:
         return {
             "date_folder": self.date_folder,
             "summary": {
+                "provider": self.provider,
+                "model": self.model,
                 "n_labels": self.n_labels,
-                "n_gemini_hits": self.n_gemini_hits,
+                "n_model_hits": self.n_model_hits,
                 "n_matched": len(self.matched),
                 "n_label_only": len(self.label_only),
-                "n_gemini_only": len(self.gemini_only),
+                "n_model_only": len(self.model_only),
                 "precision": round(self.precision, 3),
                 "recall": round(self.recall, 3),
             },
             "patterns": self.patterns,
             "matched": [h.to_dict() for h in self.matched],
             "label_only": [h.to_dict() for h in self.label_only],
-            "gemini_only": [h.to_dict() for h in self.gemini_only],
+            "model_only": [h.to_dict() for h in self.model_only],
         }
 
     def print_summary(self) -> None:
         """Print a human-readable summary to stdout."""
+        label = f"{self.provider} ({self.model})" if self.model else self.provider
         print(f"\n{'='*60}")
-        print(f"Label vs Gemini Comparison — {self.date_folder}")
+        print(f"Label vs {label} Comparison — {self.date_folder}")
         print(f"{'='*60}")
         print(f"  Labels:       {self.n_labels}")
-        print(f"  Gemini hits:  {self.n_gemini_hits}")
+        print(f"  Model hits:   {self.n_model_hits}")
         print(f"  Matched:      {len(self.matched)}")
-        print(f"  Label-only:   {len(self.label_only)}  (Gemini missed)")
-        print(f"  Gemini-only:  {len(self.gemini_only)}  (user didn't flag)")
+        print(f"  Label-only:   {len(self.label_only)}  (model missed)")
+        print(f"  Model-only:   {len(self.model_only)}  (user didn't flag)")
         print(f"  Precision:    {self.precision:.0%}")
         print(f"  Recall:       {self.recall:.0%}")
 
         if self.label_only:
-            print("\n  Gemini MISSED these labeled moments:")
+            print("\n  Model MISSED these labeled moments:")
             for h in self.label_only:
                 t = format_time(h.ride_time_secs)
                 print(f"    {t}  [{h.label_type}] {h.label_notes}")
 
-        if self.gemini_only:
-            print("\n  Gemini flagged but user DIDN'T label:")
-            for h in sorted(self.gemini_only, key=lambda x: -max(x.gemini_visual, x.gemini_action))[:10]:
+        if self.model_only:
+            print("\n  Model flagged but user DIDN'T label:")
+            for h in sorted(
+                self.model_only,
+                key=lambda x: -max(x.model_visual, x.model_action),
+            )[:10]:
                 t = format_time(h.ride_time_secs)
-                score = f"v={h.gemini_visual} a={h.gemini_action}"
-                print(f"    {t}  [{h.gemini_clip_type}] {score} — {h.gemini_reason}")
-            if len(self.gemini_only) > 10:
-                print(f"    ... and {len(self.gemini_only) - 10} more")
+                score = f"v={h.model_visual} a={h.model_action}"
+                print(f"    {t}  [{h.model_clip_type}] {score} — {h.model_reason}")
+            if len(self.model_only) > 10:
+                print(f"    ... and {len(self.model_only) - 10} more")
 
         if self.patterns:
             print("\n  Patterns:")
@@ -168,7 +338,7 @@ def _load_labels(date_folder: Path) -> list[dict]:
     """Load ride_labels.json from a date folder.
 
     Old labels saved on the 1-5 scale are upgraded to the 1-10 scale on
-    read so the comparison flow operates in a single space. Gemini hits
+    read so the comparison flow operates in a single space. Model hits
     reach the same space via `rating_visual_action`, which folds the v10
     five-dim rubric down to visual/action.
     """
@@ -176,13 +346,6 @@ def _load_labels(date_folder: Path) -> list[dict]:
     if not labels_path.exists():
         return []
     return [normalize_label_scale(lab) for lab in json.loads(labels_path.read_text())]
-
-
-def _active_model_id(settings) -> str:
-    provider = (settings.model_provider or "gemini").lower()
-    if provider == "openai":
-        return settings.openai_model
-    return settings.gemini_model
 
 
 def _cache_files_for_active_model(cache_dir: Path, provider: str, model_id: str) -> list[Path]:
@@ -210,19 +373,20 @@ def _cache_files_for_active_model(cache_dir: Path, provider: str, model_id: str)
     return matched
 
 
-def _load_gemini_hits(date_folder: Path) -> list[dict]:
+def _load_model_hits(date_folder: Path) -> list[dict]:
     """Load vision-scan hits from the active provider's cache directory.
 
     Uses ``MODEL_PROVIDER`` to pick ``.{provider}_cache/``. Does **not**
     fall back across providers (one-provider rule). Gemini still accepts
     legacy ``gemini_cache.json``. OpenAI files are filtered to the active
-    ``OPENAI_MODEL`` fingerprint.
+    ``OPENAI_MODEL`` fingerprint. When local ``*.MP4``/``*.mp4`` files
+    exist, hits for other chapters are dropped.
     """
     from .config import get_settings
     from .models import cache_dir_name
 
     settings = get_settings()
-    provider = (settings.model_provider or "gemini").lower()
+    provider = _active_provider(settings)
     model_id = _active_model_id(settings)
     cache_dir = date_folder / cache_dir_name(provider)
 
@@ -230,7 +394,11 @@ def _load_gemini_hits(date_folder: Path) -> list[dict]:
         if provider == "gemini":
             legacy = date_folder / "gemini_cache.json"
             if legacy.exists():
-                return json.loads(legacy.read_text())
+                hits = json.loads(legacy.read_text())
+                if isinstance(hits, list):
+                    return _filter_hits_to_local_chapters(
+                        hits, _local_chapter_names(date_folder),
+                    )
         return []
 
     all_hits = []
@@ -241,17 +409,25 @@ def _load_gemini_hits(date_folder: Path) -> list[dict]:
                 all_hits.extend(hits)
         except (json.JSONDecodeError, OSError):
             continue
-    return all_hits
+    return _filter_hits_to_local_chapters(all_hits, _local_chapter_names(date_folder))
+
+
+# Thin alias for callers/tests that still use the old name
+_load_gemini_hits = _load_model_hits
 
 
 def _align_moments(
-    labels: list[dict], gemini_hits: list[dict], window: float = _MATCH_WINDOW,
+    labels: list[dict],
+    model_hits: list[dict],
+    *,
+    provider: str,
+    window: float = _MATCH_WINDOW,
 ) -> tuple[list[CompareHit], list[CompareHit], list[CompareHit]]:
-    """Align labels and Gemini hits by ride time.
+    """Align labels and model hits by ride time.
 
-    Returns (matched, label_only, gemini_only).
+    Returns (matched, label_only, model_only). Model-only hits use
+    *provider* as ``CompareHit.source``.
     """
-    # Build label list with ride_time_secs
     label_moments = []
     for lab in labels:
         ride_secs = lab.get("ride_time_secs", 0)
@@ -265,16 +441,13 @@ def _align_moments(
             "video_secs": lab.get("video_secs", 0),
         })
 
-    # Build Gemini list with ride_time_secs
-    # Gemini hits use video_secs within each clip — we need to map to
-    # ride time. We store clip_name + video_secs as the key, but for
-    # comparison we need ride-relative time. If the Gemini cache
-    # doesn't have ride_time_secs, we approximate from video_secs.
-    gemini_moments = []
-    for hit in gemini_hits:
+    # Model hits use video_secs within each clip — map to ride time when
+    # ride_time_secs is present; otherwise approximate from video_secs.
+    model_moments = []
+    for hit in model_hits:
         video_secs = _hit_video_secs(hit)
         visual, action = rating_visual_action(hit)
-        gemini_moments.append({
+        model_moments.append({
             "ride_time_secs": hit.get("ride_time_secs", video_secs),
             "visual": visual,
             "action": action,
@@ -284,28 +457,26 @@ def _align_moments(
             "video_secs": video_secs,
         })
 
-    # Sort both by ride time
     label_moments.sort(key=lambda x: x["ride_time_secs"])
-    gemini_moments.sort(key=lambda x: x["ride_time_secs"])
+    model_moments.sort(key=lambda x: x["ride_time_secs"])
 
-    # Greedy matching: for each label, find closest unmatched Gemini hit
-    matched_gemini = set()
+    matched_model = set()
     matched = []
     label_only = []
 
     for lab in label_moments:
         best_idx = None
         best_dist = window + 1
-        for i, gem in enumerate(gemini_moments):
-            if i in matched_gemini:
+        for i, mom in enumerate(model_moments):
+            if i in matched_model:
                 continue
-            dist = abs(lab["ride_time_secs"] - gem["ride_time_secs"])
+            dist = abs(lab["ride_time_secs"] - mom["ride_time_secs"])
             if dist < best_dist:
                 best_dist = dist
                 best_idx = i
         if best_idx is not None and best_dist <= window:
-            gem = gemini_moments[best_idx]
-            matched_gemini.add(best_idx)
+            mom = model_moments[best_idx]
+            matched_model.add(best_idx)
             matched.append(CompareHit(
                 ride_time_secs=lab["ride_time_secs"],
                 source="both",
@@ -313,10 +484,10 @@ def _align_moments(
                 label_notes=lab["notes"],
                 label_visual=lab["visual"],
                 label_action=lab["action"],
-                gemini_visual=gem["visual"],
-                gemini_action=gem["action"],
-                gemini_clip_type=gem["clip_type"],
-                gemini_reason=gem["reason"],
+                model_visual=mom["visual"],
+                model_action=mom["action"],
+                model_clip_type=mom["clip_type"],
+                model_reason=mom["reason"],
                 clip_name=lab["clip_name"],
                 video_secs=lab["video_secs"],
             ))
@@ -332,121 +503,123 @@ def _align_moments(
                 video_secs=lab["video_secs"],
             ))
 
-    # Remaining Gemini hits = gemini-only
-    gemini_only = []
-    for i, gem in enumerate(gemini_moments):
-        if i not in matched_gemini:
-            gemini_only.append(CompareHit(
-                ride_time_secs=gem["ride_time_secs"],
-                source="gemini",
-                gemini_visual=gem["visual"],
-                gemini_action=gem["action"],
-                gemini_clip_type=gem["clip_type"],
-                gemini_reason=gem["reason"],
-                clip_name=gem["clip_name"],
-                video_secs=gem["video_secs"],
+    model_only = []
+    for i, mom in enumerate(model_moments):
+        if i not in matched_model:
+            model_only.append(CompareHit(
+                ride_time_secs=mom["ride_time_secs"],
+                source=provider,
+                model_visual=mom["visual"],
+                model_action=mom["action"],
+                model_clip_type=mom["clip_type"],
+                model_reason=mom["reason"],
+                clip_name=mom["clip_name"],
+                video_secs=mom["video_secs"],
             ))
 
-    return matched, label_only, gemini_only
+    return matched, label_only, model_only
 
 
 def _analyze_patterns(
     matched: list[CompareHit],
     label_only: list[CompareHit],
-    gemini_only: list[CompareHit],
+    model_only: list[CompareHit],
 ) -> dict:
     """Identify systematic patterns in the comparison."""
     patterns = {}
 
-    # What types does Gemini miss?
     if label_only:
         missed_types: dict[str, int] = {}
         for h in label_only:
             t = h.label_type or "unknown"
             missed_types[t] = missed_types.get(t, 0) + 1
-        patterns["gemini_misses_by_type"] = missed_types
+        patterns["model_misses_by_type"] = missed_types
 
-    # What clip_types does Gemini over-flag?
-    if gemini_only:
+    if model_only:
         over_types: dict[str, int] = {}
-        for h in gemini_only:
-            t = h.gemini_clip_type or "unknown"
+        for h in model_only:
+            t = h.model_clip_type or "unknown"
             over_types[t] = over_types.get(t, 0) + 1
-        patterns["gemini_overflag_by_clip_type"] = over_types
+        patterns["model_overflag_by_clip_type"] = over_types
 
-    # Score agreement on matched moments (label vs Gemini visual/action)
-    scored_matches = [h for h in matched if h.label_visual and h.gemini_visual]
+    scored_matches = [h for h in matched if h.label_visual and h.model_visual]
     if scored_matches:
-        visual_diffs = [h.gemini_visual - h.label_visual for h in scored_matches]
-        action_diffs = [h.gemini_action - h.label_action for h in scored_matches]
+        visual_diffs = [h.model_visual - h.label_visual for h in scored_matches]
+        action_diffs = [h.model_action - h.label_action for h in scored_matches]
         patterns["score_agreement"] = {
             "n": len(scored_matches),
             "visual_mean_diff": round(sum(visual_diffs) / len(visual_diffs), 2),
             "action_mean_diff": round(sum(action_diffs) / len(action_diffs), 2),
         }
-        # Type agreement
-        type_matches = sum(1 for h in scored_matches if h.label_type == h.gemini_clip_type)
+        type_matches = sum(1 for h in scored_matches if h.label_type == h.model_clip_type)
         patterns["type_agreement"] = {
             "matching": type_matches,
             "total": len(scored_matches),
             "rate": round(type_matches / len(scored_matches), 2),
         }
 
-    # Average Gemini scores for matched vs gemini-only
     if matched:
-        avg_matched_v = sum(h.gemini_visual for h in matched) / len(matched)
-        avg_matched_a = sum(h.gemini_action for h in matched) / len(matched)
+        avg_matched_v = sum(h.model_visual for h in matched) / len(matched)
+        avg_matched_a = sum(h.model_action for h in matched) / len(matched)
         patterns["avg_matched_scores"] = {
             "visual": round(avg_matched_v, 1),
             "action": round(avg_matched_a, 1),
         }
-    if gemini_only:
-        avg_go_v = sum(h.gemini_visual for h in gemini_only) / len(gemini_only)
-        avg_go_a = sum(h.gemini_action for h in gemini_only) / len(gemini_only)
-        patterns["avg_gemini_only_scores"] = {
+    if model_only:
+        avg_go_v = sum(h.model_visual for h in model_only) / len(model_only)
+        avg_go_a = sum(h.model_action for h in model_only) / len(model_only)
+        patterns["avg_model_only_scores"] = {
             "visual": round(avg_go_v, 1),
             "action": round(avg_go_a, 1),
         }
 
-    # Score threshold analysis: what's the min score in matched?
     if matched:
-        min_matched_score = min(max(h.gemini_visual, h.gemini_action) for h in matched)
+        min_matched_score = min(max(h.model_visual, h.model_action) for h in matched)
         patterns["min_matched_max_score"] = min_matched_score
 
     return patterns
 
 
 def compare_ride(date_folder: Path) -> CompareReport:
-    """Compare human labels vs Gemini scan for a single ride.
+    """Compare human labels vs the active vision-model scan for a single ride.
 
-    Loads labels from ride_labels.json and Gemini hits from .gemini_cache/.
-    Returns a structured CompareReport.
+    Loads labels from ride_labels.json and hits from ``.{provider}_cache/``.
+    Writes a provider/model-scoped ``prompt_eval_*.json`` report.
     """
-    date_folder = Path(date_folder)
+    from .config import get_settings
 
-    labels = _load_labels(date_folder)
-    gemini_hits = _load_gemini_hits(date_folder)
+    date_folder = Path(date_folder)
+    settings = get_settings()
+    provider = _active_provider(settings)
+    model_id = _active_model_id(settings)
+
+    local_names = _local_chapter_names(date_folder)
+    labels = _filter_labels_to_local_chapters(_load_labels(date_folder), local_names)
+    model_hits = _load_model_hits(date_folder)
 
     if not labels:
         print(f"No labels found in {date_folder}")
-    if not gemini_hits:
-        print(f"No Gemini scan results found in {date_folder}")
+    if not model_hits:
+        print(f"No {provider} scan results found in {date_folder}")
 
-    matched, label_only, gemini_only = _align_moments(labels, gemini_hits)
-    patterns = _analyze_patterns(matched, label_only, gemini_only)
+    matched, label_only, model_only = _align_moments(
+        labels, model_hits, provider=provider,
+    )
+    patterns = _analyze_patterns(matched, label_only, model_only)
 
     report = CompareReport(
         date_folder=str(date_folder),
+        provider=provider,
+        model=model_id,
         n_labels=len(labels),
-        n_gemini_hits=len(gemini_hits),
+        n_model_hits=len(model_hits),
         matched=matched,
         label_only=label_only,
-        gemini_only=gemini_only,
+        model_only=model_only,
         patterns=patterns,
     )
 
-    # Save report
-    report_path = date_folder / _REPORT_NAME
+    report_path = date_folder / _report_filename(provider, model_id)
     report_path.write_text(json.dumps(report.to_dict(), indent=2))
     print(f"Saved comparison report to {report_path}")
 
@@ -454,46 +627,46 @@ def compare_ride(date_folder: Path) -> CompareReport:
 
 
 # ═══════════════════════════════════════════════════════════════
-# Gemini-assisted prompt improvement
+# Model-assisted prompt improvement
 # ═══════════════════════════════════════════════════════════════
 
 _EVAL_SYSTEM = """You are an expert at tuning prompts for vision-language models used in video editing.
 
-You are reviewing a Gemini prompt that scores handlebar-cam cycling video frames for a highlight reel.
+You are reviewing a vision-scan prompt that scores handlebar-cam cycling video frames for a highlight reel.
 The user has manually labeled moments they found interesting, and we're comparing those labels
-against what the Gemini scan found.
+against what the configured model scan found.
 
 Your job: analyze the comparison data and suggest SPECIFIC, ACTIONABLE prompt improvements.
 
 Focus on:
-1. What types of moments does the current prompt miss? (false negatives — user labeled but Gemini didn't flag)
-2. What does the prompt over-flag? (false positives — Gemini flagged but user didn't care about)
-3. Are there scoring calibration issues? (Gemini scores too high/low for certain types)
+1. What types of moments does the current prompt miss? (false negatives — user labeled but model didn't flag)
+2. What does the prompt over-flag? (false positives — model flagged but user didn't care about)
+3. Are there scoring calibration issues? (model scores too high/low for certain types)
 4. Are there missing visual cues the prompt should mention?
 
 Be concrete. Don't say "improve the prompt" — say exactly what words to add, remove, or change."""
 
-_EVAL_TEMPLATE = """Here is the CURRENT Gemini system instruction used for scoring:
+_EVAL_TEMPLATE = """Here is the CURRENT vision-scan system instruction used for scoring:
 
 ```
 {current_prompt}
 ```
 
-Here is the comparison report for {n_rides} ride(s):
+Here is the comparison report for {n_rides} ride(s) (provider={provider}, model={model}):
 
 ## Summary
 - Total labels: {n_labels}
-- Total Gemini hits: {n_gemini_hits}
+- Total model hits: {n_model_hits}
 - Matched (both agree): {n_matched}
-- Label-only (Gemini missed): {n_label_only}
-- Gemini-only (user didn't flag): {n_gemini_only}
+- Label-only (model missed): {n_label_only}
+- Model-only (user didn't flag): {n_model_only}
 - Precision: {precision:.0%}
 - Recall: {recall:.0%}
 
-## Moments Gemini MISSED (user labeled, Gemini didn't flag)
+## Moments the model MISSED (user labeled, model didn't flag)
 {missed_details}
 
-## Moments Gemini OVER-FLAGGED (Gemini flagged, user didn't label)
+## Moments the model OVER-FLAGGED (model flagged, user didn't label)
 {overflag_details}
 
 ## Pattern Analysis
@@ -520,40 +693,69 @@ Based on this data, suggest specific prompt changes. Return a JSON object:
 
 
 def _load_all_reports(date_folders: list[Path]) -> list[dict]:
-    """Load prompt_eval.json from multiple ride folders."""
+    """Load comparison reports for the active provider/model.
+
+    Prefers scoped filenames. Legacy ``prompt_eval.json`` is only used when
+    the active provider is Gemini. Every loaded report is normalized to the
+    model_* schema.
+    """
+    from .config import get_settings
+
+    settings = get_settings()
+    provider = _active_provider(settings)
+    model_id = _active_model_id(settings)
+
     reports = []
     for folder in date_folders:
-        report_path = Path(folder) / _REPORT_NAME
-        if report_path.exists():
-            try:
-                reports.append(json.loads(report_path.read_text()))
-            except (json.JSONDecodeError, OSError):
-                continue
+        report_path = _resolve_report_path(Path(folder), provider, model_id)
+        if report_path is None:
+            continue
+        try:
+            raw = json.loads(report_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        # Reject scoped/legacy files whose embedded metadata mismatches
+        summary = raw.get("summary") or {}
+        file_provider = (summary.get("provider") or raw.get("provider") or "").lower()
+        if file_provider and file_provider != provider:
+            continue
+        file_model = summary.get("model") or raw.get("model") or ""
+        # Reject any populated mismatch — including legacy prompt_eval.json
+        if file_model and file_model != model_id:
+            continue
+        reports.append(_normalize_report(raw))
     return reports
 
 
 def _aggregate_reports(reports: list[dict]) -> dict:
-    """Aggregate multiple ride comparison reports into one summary."""
+    """Aggregate multiple ride comparison reports into one summary.
+
+    Expects reports already normalized to model_* keys.
+    """
     agg = {
         "n_rides": len(reports),
         "n_labels": sum(r["summary"]["n_labels"] for r in reports),
-        "n_gemini_hits": sum(r["summary"]["n_gemini_hits"] for r in reports),
+        "n_model_hits": sum(r["summary"]["n_model_hits"] for r in reports),
         "n_matched": sum(r["summary"]["n_matched"] for r in reports),
         "n_label_only": sum(r["summary"]["n_label_only"] for r in reports),
-        "n_gemini_only": sum(r["summary"]["n_gemini_only"] for r in reports),
+        "n_model_only": sum(r["summary"]["n_model_only"] for r in reports),
         "all_label_only": [],
-        "all_gemini_only": [],
+        "all_model_only": [],
         "all_patterns": [],
     }
     for r in reports:
         agg["all_label_only"].extend(r.get("label_only", []))
-        # Limit gemini-only to top-scoring to keep prompt manageable
-        gemini_only = r.get("gemini_only", [])
-        gemini_only.sort(key=lambda x: -max(x.get("gemini_visual", 0), x.get("gemini_action", 0)))
-        agg["all_gemini_only"].extend(gemini_only[:15])
+        # Limit model-only to top-scoring to keep prompt manageable
+        model_only = list(r.get("model_only", []))
+        model_only.sort(
+            key=lambda x: -max(x.get("model_visual", 0), x.get("model_action", 0)),
+        )
+        agg["all_model_only"].extend(model_only[:15])
         agg["all_patterns"].append(r.get("patterns", {}))
 
-    total = agg["n_matched"] + agg["n_gemini_only"]
+    total = agg["n_matched"] + agg["n_model_only"]
     agg["precision"] = agg["n_matched"] / total if total else 0.0
     total = agg["n_matched"] + agg["n_label_only"]
     agg["recall"] = agg["n_matched"] / total if total else 0.0
@@ -575,16 +777,16 @@ def _format_missed(items: list[dict]) -> str:
 
 
 def _format_overflag(items: list[dict]) -> str:
-    """Format gemini-only items for the eval prompt."""
+    """Format model-only items for the eval prompt."""
     if not items:
         return "(none)"
     lines = []
     for item in items[:20]:  # cap for prompt length
         t = item.get("ride_time_str", format_time(item.get("ride_time_secs", 0)))
-        v = item.get("gemini_visual", 0)
-        a = item.get("gemini_action", 0)
-        ct = item.get("gemini_clip_type", "")
-        reason = item.get("gemini_reason", "")
+        v = item.get("model_visual", 0)
+        a = item.get("model_action", 0)
+        ct = item.get("model_clip_type", "")
+        reason = item.get("model_reason", "")
         lines.append(f"  {t} [{ct}] v={v} a={a} — {reason}")
     if len(items) > 20:
         lines.append(f"  ... and {len(items) - 20} more")
@@ -611,7 +813,7 @@ def eval_prompt(
     Uses the same MODEL_PROVIDER as the vision scan — never a second provider.
 
     Args:
-        date_folders: List of ride date folders with prompt_eval.json files
+        date_folders: List of ride date folders with comparison reports
         current_prompt: The current fine-pass system instruction. If None,
             loads from gemini_scan._SYSTEM_INSTRUCTION (v10 placeholders).
 
@@ -623,6 +825,8 @@ def eval_prompt(
     from .models import get_model_adapter, provider_api_key
 
     settings = get_settings()
+    provider = _active_provider(settings)
+    model_id = _active_model_id(settings)
     if not provider_api_key(settings):
         print("No API key for MODEL_PROVIDER; cannot run prompt eval.")
         return {}
@@ -647,16 +851,18 @@ def eval_prompt(
 
     prompt_text = _EVAL_TEMPLATE.format(
         current_prompt=current_prompt,
+        provider=provider,
+        model=model_id,
         n_rides=agg["n_rides"],
         n_labels=agg["n_labels"],
-        n_gemini_hits=agg["n_gemini_hits"],
+        n_model_hits=agg["n_model_hits"],
         n_matched=agg["n_matched"],
         n_label_only=agg["n_label_only"],
-        n_gemini_only=agg["n_gemini_only"],
+        n_model_only=agg["n_model_only"],
         precision=agg["precision"],
         recall=agg["recall"],
         missed_details=_format_missed(agg["all_label_only"]),
-        overflag_details=_format_overflag(agg["all_gemini_only"]),
+        overflag_details=_format_overflag(agg["all_model_only"]),
         pattern_details=_format_patterns(agg["all_patterns"]),
     )
 
@@ -670,9 +876,8 @@ def eval_prompt(
     if not isinstance(result, dict):
         result = {"raw_response": result}
 
-    # Save eval result alongside reports
     for folder in date_folders:
-        eval_path = Path(folder) / "prompt_eval_suggestions.json"
+        eval_path = Path(folder) / _suggestions_filename(provider, model_id)
         eval_path.write_text(json.dumps(result, indent=2))
         print(f"Saved prompt improvement suggestions to {eval_path}")
         break  # save to first folder only
@@ -680,7 +885,7 @@ def eval_prompt(
     return result
 
 
-def enrich_gemini_hits_with_ride_time(
+def enrich_model_hits_with_ride_time(
     date_folder: Path, offset: float = 0.0,
 ) -> None:
     """Add ride_time_secs to cached vision hits so comparison can align them.
@@ -698,7 +903,6 @@ def enrich_gemini_hits_with_ride_time(
 
     date_folder = Path(date_folder)
 
-    # Find FIT + video files
     fit_files = list(date_folder.glob("*.fit")) + list(date_folder.glob("*.FIT"))
     if not fit_files:
         print("No FIT file found")
@@ -710,7 +914,7 @@ def enrich_gemini_hits_with_ride_time(
     sc_by_name = {sc.clip.path.name: sc for sc in synced_clips}
 
     settings = get_settings()
-    provider = (settings.model_provider or "gemini").lower()
+    provider = _active_provider(settings)
     model_id = _active_model_id(settings)
     cache_dir = date_folder / cache_dir_name(provider)
     if not cache_dir.exists():
@@ -744,3 +948,7 @@ def enrich_gemini_hits_with_ride_time(
         if changed:
             cache_file.write_text(json.dumps(hits, indent=2))
             print(f"  Enriched {cache_file.name} with ride_time_secs")
+
+
+# Thin alias for callers that still use the old name
+enrich_gemini_hits_with_ride_time = enrich_model_hits_with_ride_time

--- a/src/gopro_garmin_pipeline/prompt_eval.py
+++ b/src/gopro_garmin_pipeline/prompt_eval.py
@@ -63,6 +63,8 @@ def _active_model_id(settings) -> str:
     provider = _active_provider(settings)
     if provider == "openai":
         return settings.openai_model
+    if provider == "local":
+        return settings.local_model
     return settings.gemini_model
 
 

--- a/src/gopro_garmin_pipeline/prompt_eval.py
+++ b/src/gopro_garmin_pipeline/prompt_eval.py
@@ -178,18 +178,63 @@ def _load_labels(date_folder: Path) -> list[dict]:
     return [normalize_label_scale(lab) for lab in json.loads(labels_path.read_text())]
 
 
-def _load_gemini_hits(date_folder: Path) -> list[dict]:
-    """Load all Gemini scan hits from .gemini_cache/ in a date folder."""
-    cache_dir = date_folder / ".gemini_cache"
+def _active_model_id(settings) -> str:
+    provider = (settings.model_provider or "gemini").lower()
+    if provider == "openai":
+        return settings.openai_model
+    return settings.gemini_model
+
+
+def _cache_files_for_active_model(cache_dir: Path, provider: str, model_id: str) -> list[Path]:
+    """List cache JSON files for the active provider/model only.
+
+    Gemini: all ``*.json`` (legacy filenames have no model fingerprint).
+    OpenAI: only files whose name contains ``_m{fingerprint}`` for the
+    active ``OPENAI_MODEL`` — never merge results across models.
+    """
     if not cache_dir.exists():
-        # Check legacy
-        legacy = date_folder / "gemini_cache.json"
-        if legacy.exists():
-            return json.loads(legacy.read_text())
+        return []
+    files = sorted(cache_dir.glob("*.json"))
+    if provider == "gemini":
+        return files
+
+    from .gemini_scan import _model_fingerprint
+
+    fp = _model_fingerprint(model_id)
+    matched: list[Path] = []
+    for path in files:
+        stem = path.stem
+        # Keys: {stem}_{ver}_m{fp}.json or {stem}_{ver}_m{fp}_l{label}.json
+        if stem.endswith(f"_m{fp}") or f"_m{fp}_l" in stem:
+            matched.append(path)
+    return matched
+
+
+def _load_gemini_hits(date_folder: Path) -> list[dict]:
+    """Load vision-scan hits from the active provider's cache directory.
+
+    Uses ``MODEL_PROVIDER`` to pick ``.{provider}_cache/``. Does **not**
+    fall back across providers (one-provider rule). Gemini still accepts
+    legacy ``gemini_cache.json``. OpenAI files are filtered to the active
+    ``OPENAI_MODEL`` fingerprint.
+    """
+    from .config import get_settings
+    from .models import cache_dir_name
+
+    settings = get_settings()
+    provider = (settings.model_provider or "gemini").lower()
+    model_id = _active_model_id(settings)
+    cache_dir = date_folder / cache_dir_name(provider)
+
+    if not cache_dir.exists():
+        if provider == "gemini":
+            legacy = date_folder / "gemini_cache.json"
+            if legacy.exists():
+                return json.loads(legacy.read_text())
         return []
 
     all_hits = []
-    for cache_file in sorted(cache_dir.glob("*.json")):
+    for cache_file in _cache_files_for_active_model(cache_dir, provider, model_id):
         try:
             hits = json.loads(cache_file.read_text())
             if isinstance(hits, list):
@@ -561,33 +606,36 @@ def eval_prompt(
     date_folders: list[Path],
     current_prompt: str | None = None,
 ) -> dict:
-    """Use Gemini to analyze label/scan comparison and suggest prompt improvements.
+    """Analyze label/scan comparison and suggest prompt improvements.
 
-    Loads comparison reports from all provided date folders, aggregates them,
-    and asks Gemini for specific prompt change suggestions.
+    Uses the same MODEL_PROVIDER as the vision scan — never a second provider.
 
     Args:
         date_folders: List of ride date folders with prompt_eval.json files
-        current_prompt: The current Gemini system instruction. If None, loads
-            from gemini_scan._SYSTEM_INSTRUCTION.
+        current_prompt: The current fine-pass system instruction. If None,
+            loads from gemini_scan._SYSTEM_INSTRUCTION (v10 placeholders).
 
     Returns:
         Dict with analysis and suggested changes.
     """
     from .config import get_settings
-    from .gemini_scan import _SYSTEM_INSTRUCTION, _MIN_VISUAL_SCORE, _MIN_ACTION_SCORE
+    from .gemini_scan import _SYSTEM_INSTRUCTION, _build_context_strings
+    from .models import get_model_adapter, provider_api_key
+
+    settings = get_settings()
+    if not provider_api_key(settings):
+        print("No API key for MODEL_PROVIDER; cannot run prompt eval.")
+        return {}
 
     if current_prompt is None:
-        ftp = get_settings().ftp
+        power_zones, telemetry_fields, telemetry_examples = _build_context_strings(
+            True, settings.ftp,
+        )
         current_prompt = _SYSTEM_INSTRUCTION.format(
-            min_visual=_MIN_VISUAL_SCORE, min_action=_MIN_ACTION_SCORE,
-            ftp=ftp,
-            z1=int(ftp * 0.55),
-            z2=int(ftp * 0.75),
-            z3=int(ftp * 0.90),
-            z4=int(ftp * 1.05),
-            z5=int(ftp * 1.20),
-            z6=int(ftp * 1.50),
+            n_frames=6,
+            power_zones=power_zones,
+            telemetry_fields=telemetry_fields,
+            telemetry_examples=telemetry_examples,
         )
 
     reports = _load_all_reports(date_folders)
@@ -612,23 +660,15 @@ def eval_prompt(
         pattern_details=_format_patterns(agg["all_patterns"]),
     )
 
-    settings = get_settings()
-    from google import genai
-    from google.genai import types
-
-    client = genai.Client(api_key=settings.gemini_api_key)
-    response = client.models.generate_content(
-        model=settings.gemini_model,
-        contents=[types.Content(parts=[types.Part.from_text(text=prompt_text)])],
-        config=types.GenerateContentConfig(
-            system_instruction=_EVAL_SYSTEM,
-        ),
+    adapter = get_model_adapter(settings)
+    result = adapter.complete_json(
+        prompt=prompt_text,
+        system=_EVAL_SYSTEM,
+        temperature=0.3,
+        max_output_tokens=2048,
     )
-
-    from .utils import parse_json_response
-    result = parse_json_response(response.text)
     if not isinstance(result, dict):
-        result = {"raw_response": response.text}
+        result = {"raw_response": result}
 
     # Save eval result alongside reports
     for folder in date_folders:
@@ -643,14 +683,17 @@ def eval_prompt(
 def enrich_gemini_hits_with_ride_time(
     date_folder: Path, offset: float = 0.0,
 ) -> None:
-    """Add ride_time_secs to cached Gemini hits so comparison can align them.
+    """Add ride_time_secs to cached vision hits so comparison can align them.
 
-    Gemini cache stores video_secs per clip. This function maps each hit
+    Cache stores video_secs per clip. This function maps each hit
     to ride-relative time using FIT + GoPro sync, then re-saves the cache.
+    Uses the active MODEL_PROVIDER cache directory.
     """
     import datetime as dt
+    from .config import get_settings
     from .fit_parser import parse_fit
     from .gopro_meta import extract_all
+    from .models import cache_dir_name
     from .sync import normalize_tz, sync_all
 
     date_folder = Path(date_folder)
@@ -666,11 +709,14 @@ def enrich_gemini_hits_with_ride_time(
     synced_clips = sync_all(clips, ride, offset)
     sc_by_name = {sc.clip.path.name: sc for sc in synced_clips}
 
-    cache_dir = date_folder / ".gemini_cache"
+    settings = get_settings()
+    provider = (settings.model_provider or "gemini").lower()
+    model_id = _active_model_id(settings)
+    cache_dir = date_folder / cache_dir_name(provider)
     if not cache_dir.exists():
         return
 
-    for cache_file in sorted(cache_dir.glob("*.json")):
+    for cache_file in _cache_files_for_active_model(cache_dir, provider, model_id):
         try:
             hits = json.loads(cache_file.read_text())
         except (json.JSONDecodeError, OSError):

--- a/src/gopro_garmin_pipeline/proposals.py
+++ b/src/gopro_garmin_pipeline/proposals.py
@@ -1,7 +1,7 @@
 """Unified moment-proposal model.
 
 A MomentProposal is the single canonical object describing one candidate
-clip in the highlight reel pipeline. Telemetry highlights, Gemini vision
+clip in the highlight reel pipeline. Telemetry highlights, vision-model
 hits, Strava segments, and manual labels all map onto this shape. The
 reviewer (whichever one is in use) reads + writes proposals; the
 composer consumes approved proposals.

--- a/src/gopro_garmin_pipeline/utils.py
+++ b/src/gopro_garmin_pipeline/utils.py
@@ -20,7 +20,7 @@ M_TO_FT = 3.28084
 def keep_system_awake(reason: str = "long-running pipeline"):
     """Prevent macOS from sleeping or throttling for the duration of a block.
 
-    The 4K libx264 burns and Gemini scans take 10-30 minutes. If the
+    The 4K libx264 burns and vision-model scans take 10-30 minutes. If the
     display sleeps mid-run, macOS aggressively throttles the Python
     process via App Nap and Power Nap — clips that normally take 45s
     can run for 90+ minutes overnight.

--- a/tests/test_model_adapters.py
+++ b/tests/test_model_adapters.py
@@ -18,6 +18,7 @@ from gopro_garmin_pipeline.models import (
     cache_dir_name,
     get_model_adapter,
     provider_api_key,
+    provider_model_id,
 )
 from gopro_garmin_pipeline.models.base import ClipRubric, CoarseFrameBatch, FrameScore
 from gopro_garmin_pipeline.models.local_vlm import (
@@ -117,6 +118,29 @@ def test_cache_dir_name():
     assert cache_dir_name("gemini") == ".gemini_cache"
     assert cache_dir_name("openai") == ".openai_cache"
     assert cache_dir_name("local") == ".local_cache"
+
+
+def test_provider_model_id_selects_local_model():
+    settings = Settings(
+        _env_file=None,
+        model_provider="local",
+        gemini_model="gemini-3.5-flash",
+        local_model="mlx-community/Qwen3-VL-8B-Instruct-3bit",
+    )
+    assert provider_model_id(settings) == "mlx-community/Qwen3-VL-8B-Instruct-3bit"
+
+
+def test_cli_exposes_skip_vision_with_legacy_alias():
+    from click.testing import CliRunner
+
+    from gopro_garmin_pipeline.cli import main
+
+    runner = CliRunner()
+    for command in ("compose", "process", "compare-features"):
+        result = runner.invoke(main, [command, "--help"])
+        assert result.exit_code == 0
+        assert "--skip-vision, --skip-gemini" in result.output
+        assert "configured vision-model scan" in result.output
 
 
 # ─── Cache keys ───────────────────────────────────────────────
@@ -804,6 +828,50 @@ def test_load_hits_keeps_all_when_no_local_mp4(tmp_path, monkeypatch):
             "GX010001.MP4",
             "GX010002.MP4",
         }
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_compare_without_mp4_uses_labeled_chapter_tier(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import compare_ride
+
+    cache = tmp_path / ".gemini_cache"
+    cache.mkdir()
+    (cache / "GX01_v10.json").write_text(json.dumps([
+        {
+            "clip_name": "GX010001.MP4",
+            "ride_time_secs": 10,
+            "rubric": {
+                "light": 5, "composition": 7, "motion": 4,
+                "scenery": 7, "subject": 4,
+            },
+        },
+        {
+            "clip_name": "GX010099.MP4",
+            "ride_time_secs": 20,
+            "rubric": {
+                "light": 5, "composition": 6, "motion": 4,
+                "scenery": 6, "subject": 4,
+            },
+        },
+    ]))
+    (tmp_path / "ride_labels.json").write_text(json.dumps([{
+        "clip_name": "GX010001.MP4",
+        "ride_time_secs": 10,
+        "visual": 7,
+        "action": 4,
+        "scale_version": 2,
+    }]))
+
+    monkeypatch.setenv("MODEL_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-3.5-flash")
+    cfg.get_settings.cache_clear()
+    try:
+        report = compare_ride(tmp_path)
+        assert report.n_labels == 1
+        assert report.n_model_hits == 1
+        assert len(report.matched) == 1
     finally:
         cfg.get_settings.cache_clear()
 

--- a/tests/test_model_adapters.py
+++ b/tests/test_model_adapters.py
@@ -1,0 +1,418 @@
+"""Unit tests for the shared ModelAdapter layer — no network."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gopro_garmin_pipeline.config import Settings
+from gopro_garmin_pipeline.gemini_scan import _clip_cache_key, _model_fingerprint
+from gopro_garmin_pipeline.models import (
+    VISION_SOURCES,
+    GeminiAdapter,
+    OpenAIAdapter,
+    cache_dir_name,
+    get_model_adapter,
+    provider_api_key,
+)
+from gopro_garmin_pipeline.models.base import ClipRubric, CoarseFrameBatch, FrameScore
+
+
+# ─── Factory / config ─────────────────────────────────────────
+
+def test_provider_api_key_selects_by_model_provider():
+    g = Settings(_env_file=None, model_provider="gemini", gemini_api_key="gk", openai_api_key="ok")
+    assert provider_api_key(g) == "gk"
+    o = Settings(_env_file=None, model_provider="openai", gemini_api_key="gk", openai_api_key="ok")
+    assert provider_api_key(o) == "ok"
+
+
+def test_get_model_adapter_gemini():
+    s = Settings(_env_file=None, model_provider="gemini", gemini_api_key="gk", gemini_model="gemini-3.5-flash")
+    with patch("gopro_garmin_pipeline.models.gemini.genai", create=True):
+        # GeminiAdapter imports google.genai inside __init__
+        with patch("google.genai.Client") as Client:
+            Client.return_value = MagicMock()
+            adapter = get_model_adapter(s)
+    assert adapter.name == "gemini"
+    assert adapter.model_id == "gemini-3.5-flash"
+
+
+def test_get_model_adapter_openai():
+    s = Settings(
+        _env_file=None,
+        model_provider="openai",
+        openai_api_key="sk-test",
+        openai_model="gpt-4.1-mini",
+    )
+    with patch("openai.OpenAI") as OpenAI:
+        OpenAI.return_value = MagicMock()
+        adapter = get_model_adapter(s)
+    assert adapter.name == "openai"
+    assert adapter.model_id == "gpt-4.1-mini"
+
+
+def test_get_model_adapter_unknown_raises():
+    s = Settings(_env_file=None, model_provider="anthropic", gemini_api_key="x")
+    with pytest.raises(ValueError, match="Unknown MODEL_PROVIDER"):
+        get_model_adapter(s)
+
+
+def test_cache_dir_name():
+    assert cache_dir_name("gemini") == ".gemini_cache"
+    assert cache_dir_name("openai") == ".openai_cache"
+
+
+# ─── Cache keys ───────────────────────────────────────────────
+
+def test_gemini_cache_key_legacy_shape():
+    assert _clip_cache_key("GX010346.MP4", provider="gemini", model_id="gemini-3.5-flash") == (
+        "GX010346_v10.json"
+    )
+    assert _clip_cache_key(
+        "GX010346.MP4", [12.3, 45.6], provider="gemini", model_id="m",
+    ).startswith("GX010346_v10_l")
+    assert "_m" not in _clip_cache_key("GX010346.MP4", provider="gemini", model_id="gemini-3.5-flash")
+
+
+def test_openai_cache_key_includes_model_fingerprint():
+    fp = _model_fingerprint("gpt-4.1-mini")
+    key = _clip_cache_key("GX010346.MP4", provider="openai", model_id="gpt-4.1-mini")
+    assert key == f"GX010346_v10_m{fp}.json"
+
+    other = _clip_cache_key("GX010346.MP4", provider="openai", model_id="gpt-5-mini")
+    assert other != key
+    assert f"m{_model_fingerprint('gpt-5-mini')}" in other
+
+
+# ─── Transient errors ─────────────────────────────────────────
+
+def test_gemini_is_transient_error():
+    adapter = object.__new__(GeminiAdapter)
+    assert adapter.is_transient_error(Exception("503 UNAVAILABLE"))
+    assert adapter.is_transient_error(Exception("rate 429 limit"))
+    assert not adapter.is_transient_error(Exception("INVALID_ARGUMENT bad prompt"))
+
+
+def test_openai_is_transient_error():
+    adapter = object.__new__(OpenAIAdapter)
+
+    class FakeRateLimit(Exception):
+        status_code = 429
+
+    class FakeServer(Exception):
+        status_code = 503
+
+    class FakeBadRequest(Exception):
+        status_code = 400
+
+    # Typed openai exceptions (if importable) + status_code fallback
+    try:
+        from openai import RateLimitError, APITimeoutError, APIConnectionError, InternalServerError
+        # These may need constructor args — fall back to duck-typed checks
+        _ = (RateLimitError, APITimeoutError, APIConnectionError, InternalServerError)
+    except ImportError:
+        pass
+
+    assert adapter.is_transient_error(FakeRateLimit("rate limited"))
+    assert adapter.is_transient_error(FakeServer("backend error"))
+    assert adapter.is_transient_error(Exception("connection Timeout"))
+    assert not adapter.is_transient_error(FakeBadRequest("bad request"))
+
+
+def test_call_with_retry_uses_adapter_transient(monkeypatch):
+    from gopro_garmin_pipeline import gemini_scan as gs
+
+    sleeps: list[float] = []
+    monkeypatch.setattr(gs.time, "sleep", lambda s: sleeps.append(s))
+
+    class Flaky:
+        name = "test"
+        model_id = "t"
+        calls = 0
+
+        def score_frames(self, **kwargs):
+            self.calls += 1
+            if self.calls < 3:
+                raise Exception("503 UNAVAILABLE")
+            return [{"frame_index": 0, "visual": 4, "action": 4}]
+
+        def is_transient_error(self, exc):
+            return "503" in str(exc)
+
+    adapter = Flaky()
+    # Avoid reading real files — stub _call_batch path via score_frames through _call_with_retry
+    # by stubbing _read_images and prompt builders via calling _call_with_retry after patching _call_batch
+
+    def fake_batch(adapter, frame_paths, telemetry_text, n_frames, interval, has_power=True):
+        return adapter.score_frames(images=[], system="", user="")
+
+    monkeypatch.setattr(gs, "_call_batch", fake_batch)
+    out = gs._call_with_retry(adapter, [], "tel", 1, 10.0, label="t")
+    assert out == [{"frame_index": 0, "visual": 4, "action": 4}]
+    assert adapter.calls == 3
+    assert len(sleeps) == 2
+
+
+def test_call_with_retry_hard_fails_non_transient(monkeypatch):
+    from gopro_garmin_pipeline import gemini_scan as gs
+
+    class HardFail:
+        name = "test"
+        model_id = "t"
+
+        def score_frames(self, **kwargs):
+            raise Exception("INVALID_ARGUMENT")
+
+        def is_transient_error(self, exc):
+            return False
+
+    monkeypatch.setattr(
+        gs, "_call_batch",
+        lambda *a, **k: HardFail().score_frames(),
+    )
+    # Use HardFail for is_transient_error
+    adapter = HardFail()
+    errors = gs._ScanErrors()
+    out = gs._call_with_retry(adapter, [], "tel", 1, 10.0, label="t", errors=errors)
+    assert out is None
+    assert errors.count == 1
+
+
+# ─── OpenAI structured unwrap ─────────────────────────────────
+
+def test_openai_score_frames_unwraps_frames():
+    adapter = object.__new__(OpenAIAdapter)
+    adapter.model_id = "gpt-4.1-mini"
+    client = MagicMock()
+    parsed = CoarseFrameBatch(frames=[
+        FrameScore(frame_index=0, visual=5, action=3, clip_type="landmark", crop_x=50, reason="bridge"),
+    ])
+    client.responses.parse.return_value = MagicMock(output_parsed=parsed)
+    adapter._client = client
+
+    out = adapter.score_frames(images=[b"\xff\xd8fake"], system="sys", user="user")
+    assert out == [{
+        "frame_index": 0, "visual": 5, "action": 3,
+        "clip_type": "landmark", "crop_x": 50, "reason": "bridge",
+    }]
+    assert client.responses.parse.called
+
+
+def test_openai_score_clip_rubric():
+    adapter = object.__new__(OpenAIAdapter)
+    adapter.model_id = "gpt-4.1-mini"
+    client = MagicMock()
+    parsed = ClipRubric(
+        light=8, composition=7, motion=9, scenery=6, subject=9,
+        peak_offset=0.5, clip_type="action", crop_x=50, reason="sprint",
+    )
+    client.responses.parse.return_value = MagicMock(output_parsed=parsed)
+    adapter._client = client
+
+    out = adapter.score_clip_rubric(images=[b"x"], system="sys", user="user")
+    assert out["motion"] == 9
+    assert out["clip_type"] == "action"
+
+
+def test_openai_score_clip_rubric_none_raises():
+    adapter = object.__new__(OpenAIAdapter)
+    adapter.model_id = "gpt-4.1-mini"
+    client = MagicMock()
+    client.responses.parse.return_value = MagicMock(output_parsed=None)
+    adapter._client = client
+
+    with pytest.raises(ValueError, match="no structured output"):
+        adapter.score_clip_rubric(images=[b"x"], system="sys", user="user")
+
+
+def test_openai_complete_json_narrative_uses_structured_indices():
+    from gopro_garmin_pipeline.models.base import NarrativeIndices
+
+    adapter = object.__new__(OpenAIAdapter)
+    adapter.model_id = "gpt-4.1-mini"
+    client = MagicMock()
+    client.responses.parse.return_value = MagicMock(
+        output_parsed=NarrativeIndices(indices=[0, 5, 3]),
+    )
+    adapter._client = client
+
+    out = adapter.complete_json(prompt="pick clips")
+    assert out == [0, 5, 3]
+    assert client.responses.parse.called
+    assert client.responses.create.call_count == 0
+
+
+def test_openai_complete_json_eval_uses_structured_schema():
+    from gopro_garmin_pipeline.models.base import PromptEvalResult
+
+    adapter = object.__new__(OpenAIAdapter)
+    adapter.model_id = "gpt-4.1-mini"
+    client = MagicMock()
+    client.responses.parse.return_value = MagicMock(
+        output_parsed=PromptEvalResult(analysis="over-scores tunnels"),
+    )
+    adapter._client = client
+
+    out = adapter.complete_json(prompt="eval", system="you are an expert")
+    assert out["analysis"] == "over-scores tunnels"
+    assert "prompt_changes" in out
+
+
+def test_gemini_score_frames_parses_list():
+    adapter = object.__new__(GeminiAdapter)
+    adapter.model_id = "gemini-3.5-flash"
+    client = MagicMock()
+    client.models.generate_content.return_value = MagicMock(
+        text='[{"frame_index": 1, "visual": 4, "action": 2}]',
+    )
+    adapter._client = client
+
+    out = adapter.score_frames(images=[b"x"], system="sys", user="user")
+    assert out[0]["frame_index"] == 1
+
+
+# ─── Downstream compat ────────────────────────────────────────
+
+def test_learned_ranker_has_gemini_true_for_openai():
+    from gopro_garmin_pipeline.learned_ranker import _extract_features
+
+    feats = _extract_features({
+        "score": 7.0,
+        "sources": ["openai", "telemetry"],
+        "notes": "",
+        "rubric": {"composition": 8, "scenery": 7, "motion": 6, "subject": 5},
+    })
+    assert feats["has_gemini"] == 1.0
+
+
+def test_learned_ranker_has_gemini_false_without_vision():
+    from gopro_garmin_pipeline.learned_ranker import _extract_features
+
+    feats = _extract_features({
+        "score": 3.0,
+        "sources": ["telemetry"],
+        "notes": "",
+    })
+    assert feats["has_gemini"] == 0.0
+
+
+def test_vision_sources_constant():
+    assert VISION_SOURCES == frozenset({"gemini", "openai"})
+
+
+def test_hits_to_segments_uses_provider_identity():
+    from gopro_garmin_pipeline.gemini_scan import _hits_to_segments
+
+    # Minimal fake synced clip / ride — skip if Segment construction needs more
+    class FakeClip:
+        path = Path("GX01.MP4")
+        creation_time = None
+
+    class FakeSC:
+        clip = FakeClip()
+        offset_secs = 0.0
+
+    class FakeRide:
+        start_time = None
+
+    FakeClip.creation_time = __import__("datetime").datetime(2026, 1, 1)
+
+    hits = [{
+        "clip_name": "GX01.MP4",
+        "video_start": 10.0,
+        "video_end": 20.0,
+        "anchor_video_secs": 15.0,
+        "rubric": {"light": 5, "composition": 5, "motion": 5, "scenery": 5, "subject": 5},
+        "raw_sum": 25,
+        "reason": "test",
+        "clip_type": "scenery",
+        "crop_x": 50,
+    }]
+    segs = _hits_to_segments(hits, [FakeSC()], FakeRide(), None, provider="openai")
+    assert len(segs) == 1
+    assert segs[0].source == "openai"
+    assert segs[0].label["type"] == "openai_vision"
+
+
+def test_default_openai_model_is_not_gpt4o():
+    s = Settings(_env_file=None)
+    assert s.openai_model == "gpt-4.1-mini"
+    assert s.model_provider == "gemini"
+
+
+def test_openai_dependency_floor_supports_responses_parse():
+    """pyproject floor must be high enough that client.responses.parse exists."""
+    import importlib.metadata
+    import re
+    from pathlib import Path
+
+    text = Path("pyproject.toml").read_text()
+    m = re.search(r'"openai>=([^"]+)"', text)
+    assert m, "openai dependency missing from pyproject.toml"
+    floor = m.group(1)
+    parts = [int(x) for x in floor.split(".")]
+    assert parts >= [1, 66, 0], f"openai floor {floor} predates responses.parse"
+
+    # Installed SDK must expose the API we call.
+    ver = importlib.metadata.version("openai")
+    assert tuple(int(x) for x in ver.split(".")[:3]) >= (1, 66, 0)
+    from openai import OpenAI
+    client = OpenAI(api_key="sk-test")
+    assert hasattr(client, "responses")
+    assert hasattr(client.responses, "parse")
+
+
+def test_cache_files_filter_by_openai_model(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.gemini_scan import _model_fingerprint
+    from gopro_garmin_pipeline.prompt_eval import (
+        _cache_files_for_active_model,
+        _load_gemini_hits,
+    )
+
+    cache = tmp_path / ".openai_cache"
+    cache.mkdir()
+    fp_a = _model_fingerprint("gpt-4.1-mini")
+    fp_b = _model_fingerprint("gpt-5-mini")
+    (cache / f"GX01_v10_m{fp_a}.json").write_text('[{"clip_name": "a"}]')
+    (cache / f"GX01_v10_m{fp_b}.json").write_text('[{"clip_name": "b"}]')
+    (cache / f"GX02_v10_m{fp_a}_ldeadbeef.json").write_text('[{"clip_name": "a2"}]')
+
+    matched = _cache_files_for_active_model(cache, "openai", "gpt-4.1-mini")
+    assert {p.name for p in matched} == {
+        f"GX01_v10_m{fp_a}.json",
+        f"GX02_v10_m{fp_a}_ldeadbeef.json",
+    }
+
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4.1-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg.get_settings.cache_clear()
+    try:
+        hits = _load_gemini_hits(tmp_path)
+        names = {h["clip_name"] for h in hits}
+        assert names == {"a", "a2"}
+        assert "b" not in names
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_load_hits_no_cross_provider_fallback(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import _load_gemini_hits
+
+    gem = tmp_path / ".gemini_cache"
+    gem.mkdir()
+    (gem / "GX01_v10.json").write_text('[{"clip_name": "gemini-only"}]')
+
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4.1-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg.get_settings.cache_clear()
+    try:
+        assert _load_gemini_hits(tmp_path) == []
+    finally:
+        cfg.get_settings.cache_clear()

--- a/tests/test_model_adapters.py
+++ b/tests/test_model_adapters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -370,16 +371,22 @@ def test_cache_files_filter_by_openai_model(tmp_path, monkeypatch):
     from gopro_garmin_pipeline.gemini_scan import _model_fingerprint
     from gopro_garmin_pipeline.prompt_eval import (
         _cache_files_for_active_model,
-        _load_gemini_hits,
+        _load_model_hits,
     )
 
     cache = tmp_path / ".openai_cache"
     cache.mkdir()
     fp_a = _model_fingerprint("gpt-4.1-mini")
     fp_b = _model_fingerprint("gpt-5-mini")
-    (cache / f"GX01_v10_m{fp_a}.json").write_text('[{"clip_name": "a"}]')
-    (cache / f"GX01_v10_m{fp_b}.json").write_text('[{"clip_name": "b"}]')
-    (cache / f"GX02_v10_m{fp_a}_ldeadbeef.json").write_text('[{"clip_name": "a2"}]')
+    (cache / f"GX01_v10_m{fp_a}.json").write_text(
+        '[{"clip_name": "GX010001.MP4"}]',
+    )
+    (cache / f"GX01_v10_m{fp_b}.json").write_text(
+        '[{"clip_name": "GX010099.MP4"}]',
+    )
+    (cache / f"GX02_v10_m{fp_a}_ldeadbeef.json").write_text(
+        '[{"clip_name": "GX010002.MP4"}]',
+    )
 
     matched = _cache_files_for_active_model(cache, "openai", "gpt-4.1-mini")
     assert {p.name for p in matched} == {
@@ -392,27 +399,407 @@ def test_cache_files_filter_by_openai_model(tmp_path, monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     cfg.get_settings.cache_clear()
     try:
-        hits = _load_gemini_hits(tmp_path)
+        hits = _load_model_hits(tmp_path)
         names = {h["clip_name"] for h in hits}
-        assert names == {"a", "a2"}
-        assert "b" not in names
+        assert names == {"GX010001.MP4", "GX010002.MP4"}
+        assert "GX010099.MP4" not in names
     finally:
         cfg.get_settings.cache_clear()
 
 
 def test_load_hits_no_cross_provider_fallback(tmp_path, monkeypatch):
     from gopro_garmin_pipeline import config as cfg
-    from gopro_garmin_pipeline.prompt_eval import _load_gemini_hits
+    from gopro_garmin_pipeline.prompt_eval import _load_model_hits
 
     gem = tmp_path / ".gemini_cache"
     gem.mkdir()
-    (gem / "GX01_v10.json").write_text('[{"clip_name": "gemini-only"}]')
+    (gem / "GX01_v10.json").write_text('[{"clip_name": "GX010001.MP4"}]')
 
     monkeypatch.setenv("MODEL_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_MODEL", "gpt-4.1-mini")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     cfg.get_settings.cache_clear()
     try:
-        assert _load_gemini_hits(tmp_path) == []
+        assert _load_model_hits(tmp_path) == []
     finally:
         cfg.get_settings.cache_clear()
+
+
+# ─── Compare naming / local chapters / report filenames ────────
+
+
+def test_sanitize_model_id_strips_unsafe_chars():
+    import hashlib
+
+    from gopro_garmin_pipeline.prompt_eval import (
+        _report_filename,
+        _sanitize_model_id,
+    )
+
+    assert _sanitize_model_id("gpt-4.1-mini") == "gpt-4.1-mini"
+    # Changed-by-sanitize ids get a stable hash suffix
+    raw = "org/model:v1"
+    fp = hashlib.sha1(raw.encode()).hexdigest()[:8]
+    assert _sanitize_model_id(raw) == f"org-model-v1_{fp}"
+    assert "/" not in _sanitize_model_id("x/y")
+    assert "\\" not in _sanitize_model_id("x\\y")
+    name = _report_filename("openai", "org/weird model:v2")
+    assert name.startswith("prompt_eval_openai_org-weird-model-v2_")
+    assert name.endswith(".json")
+    assert "/" not in name
+    assert " " not in name
+
+
+def test_sanitize_model_id_avoids_collision_with_hash_suffix():
+    from gopro_garmin_pipeline.prompt_eval import (
+        _report_filename,
+        _sanitize_model_id,
+    )
+
+    a = _sanitize_model_id("org/model:v1")
+    b = _sanitize_model_id("org-model-v1")
+    assert a != b
+    assert b == "org-model-v1"  # already safe — no hash
+    assert a.startswith("org-model-v1_")
+    assert _report_filename("openai", "org/model:v1") != _report_filename(
+        "openai", "org-model-v1",
+    )
+
+
+def test_load_hits_filters_to_local_chapters(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import _load_model_hits
+
+    cache = tmp_path / ".gemini_cache"
+    cache.mkdir()
+    (cache / "GX01_v10.json").write_text(
+        json.dumps([
+            {"clip_name": "GX010001.MP4", "ride_time_secs": 10},
+            {"clip_name": "GX010002.MP4", "ride_time_secs": 20},
+        ]),
+    )
+    (tmp_path / "GX010001.MP4").write_bytes(b"fake")
+
+    monkeypatch.setenv("MODEL_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    cfg.get_settings.cache_clear()
+    try:
+        hits = _load_model_hits(tmp_path)
+        assert [h["clip_name"] for h in hits] == ["GX010001.MP4"]
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_load_hits_keeps_all_when_no_local_mp4(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import _load_model_hits
+
+    cache = tmp_path / ".gemini_cache"
+    cache.mkdir()
+    (cache / "GX01_v10.json").write_text(
+        json.dumps([
+            {"clip_name": "GX010001.MP4"},
+            {"clip_name": "GX010002.MP4"},
+        ]),
+    )
+
+    monkeypatch.setenv("MODEL_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    cfg.get_settings.cache_clear()
+    try:
+        hits = _load_model_hits(tmp_path)
+        assert {h["clip_name"] for h in hits} == {
+            "GX010001.MP4",
+            "GX010002.MP4",
+        }
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_filter_labels_keeps_missing_clip_name():
+    from gopro_garmin_pipeline.prompt_eval import _filter_labels_to_local_chapters
+
+    local = {"GX010001.MP4"}
+    labels = [
+        {"notes": "legacy", "ride_time_secs": 1},
+        {"clip_name": "", "notes": "empty", "ride_time_secs": 2},
+        {"clip_name": "GX010001.MP4", "notes": "present", "ride_time_secs": 3},
+        {"clip_name": "GX010099.MP4", "notes": "absent", "ride_time_secs": 4},
+    ]
+    kept = _filter_labels_to_local_chapters(labels, local)
+    notes = [lab["notes"] for lab in kept]
+    assert notes == ["legacy", "empty", "present"]
+
+
+def test_align_moments_openai_model_only_source():
+    from gopro_garmin_pipeline.prompt_eval import _align_moments
+
+    labels = []
+    hits = [{
+        "clip_name": "GX010001.MP4",
+        "ride_time_secs": 100,
+        "visual": 8,
+        "action": 3,
+        "clip_type": "scenery",
+        "reason": "view",
+    }]
+    matched, label_only, model_only = _align_moments(
+        labels, hits, provider="openai",
+    )
+    assert matched == []
+    assert label_only == []
+    assert len(model_only) == 1
+    assert model_only[0].source == "openai"
+    assert model_only[0].model_visual == 8
+
+
+def test_compare_report_emits_model_fields_and_scoped_filename(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import (
+        CompareHit,
+        _report_filename,
+        compare_ride,
+    )
+
+    cache = tmp_path / ".openai_cache"
+    cache.mkdir()
+    from gopro_garmin_pipeline.gemini_scan import _model_fingerprint
+
+    fp = _model_fingerprint("gpt-4.1-mini")
+    (cache / f"GX01_v10_m{fp}.json").write_text(
+        json.dumps([{
+            "clip_name": "GX010001.MP4",
+            "ride_time_secs": 50,
+            "visual": 7,
+            "action": 2,
+            "clip_type": "scenery",
+            "reason": "ridge",
+        }]),
+    )
+    (tmp_path / "GX010001.MP4").write_bytes(b"fake")
+    (tmp_path / "ride_labels.json").write_text("[]")
+
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4.1-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg.get_settings.cache_clear()
+    try:
+        report = compare_ride(tmp_path)
+        assert report.provider == "openai"
+        assert report.n_model_hits == 1
+        d = report.to_dict()
+        assert d["summary"]["n_model_hits"] == 1
+        assert d["summary"]["provider"] == "openai"
+        assert "model_only" in d
+        assert "gemini_only" not in d
+        assert d["model_only"][0]["source"] == "openai"
+        assert d["model_only"][0]["model_visual"] == 7
+
+        scoped = tmp_path / _report_filename("openai", "gpt-4.1-mini")
+        assert scoped.exists()
+        assert not (tmp_path / "prompt_eval.json").exists()
+    finally:
+        cfg.get_settings.cache_clear()
+
+    hit = CompareHit(
+        ride_time_secs=1, source="both",
+        model_visual=5, model_action=4, model_clip_type="x", model_reason="y",
+    )
+    assert "model_visual" in hit.to_dict()
+    assert "gemini_visual" not in hit.to_dict()
+
+
+def test_scoped_report_takes_precedence_over_legacy(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import (
+        _load_all_reports,
+        _report_filename,
+    )
+
+    scoped = {
+        "summary": {
+            "provider": "gemini",
+            "model": "gemini-3.5-flash",
+            "n_labels": 1,
+            "n_model_hits": 1,
+            "n_matched": 1,
+            "n_label_only": 0,
+            "n_model_only": 0,
+        },
+        "matched": [],
+        "label_only": [],
+        "model_only": [{"source": "scoped"}],
+        "patterns": {},
+    }
+    legacy = {
+        "summary": {
+            "n_labels": 9,
+            "n_gemini_hits": 9,
+            "n_matched": 0,
+            "n_label_only": 0,
+            "n_gemini_only": 9,
+        },
+        "gemini_only": [{"source": "legacy"}],
+        "label_only": [],
+        "matched": [],
+        "patterns": {},
+    }
+    (tmp_path / _report_filename("gemini", "gemini-3.5-flash")).write_text(
+        json.dumps(scoped),
+    )
+    (tmp_path / "prompt_eval.json").write_text(json.dumps(legacy))
+
+    monkeypatch.setenv("MODEL_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-3.5-flash")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    cfg.get_settings.cache_clear()
+    try:
+        reports = _load_all_reports([tmp_path])
+        assert len(reports) == 1
+        assert reports[0]["model_only"][0]["source"] == "scoped"
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_openai_does_not_fallback_to_legacy_gemini_report(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import _load_all_reports
+
+    (tmp_path / "prompt_eval.json").write_text(json.dumps({
+        "summary": {
+            "n_labels": 1,
+            "n_gemini_hits": 1,
+            "n_matched": 0,
+            "n_label_only": 0,
+            "n_gemini_only": 1,
+        },
+        "gemini_only": [{"gemini_visual": 8}],
+        "label_only": [],
+        "matched": [],
+        "patterns": {},
+    }))
+
+    monkeypatch.setenv("MODEL_PROVIDER", "openai")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-4.1-mini")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    cfg.get_settings.cache_clear()
+    try:
+        assert _load_all_reports([tmp_path]) == []
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_gemini_falls_back_to_legacy_prompt_eval(tmp_path, monkeypatch):
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import _load_all_reports
+
+    (tmp_path / "prompt_eval.json").write_text(json.dumps({
+        "summary": {
+            "n_labels": 1,
+            "n_gemini_hits": 2,
+            "n_matched": 0,
+            "n_label_only": 1,
+            "n_gemini_only": 1,
+        },
+        "gemini_only": [{"gemini_visual": 8, "gemini_action": 2}],
+        "label_only": [],
+        "matched": [],
+        "patterns": {"gemini_misses_by_type": {"scenery": 1}},
+    }))
+
+    monkeypatch.setenv("MODEL_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-3.5-flash")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    cfg.get_settings.cache_clear()
+    try:
+        reports = _load_all_reports([tmp_path])
+        assert len(reports) == 1
+        r = reports[0]
+        assert r["summary"]["n_model_hits"] == 2
+        assert r["summary"]["n_model_only"] == 1
+        assert "n_gemini_hits" not in r["summary"]
+        assert r["summary"]["provider"] == "gemini"
+        assert "model_only" in r
+        assert r["model_only"][0]["model_visual"] == 8
+        assert "gemini_visual" not in r["model_only"][0]
+        assert "model_misses_by_type" in r["patterns"]
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_legacy_report_rejects_mismatching_model(tmp_path, monkeypatch):
+    """Legacy prompt_eval.json with an explicit different model must be rejected."""
+    from gopro_garmin_pipeline import config as cfg
+    from gopro_garmin_pipeline.prompt_eval import _load_all_reports
+
+    (tmp_path / "prompt_eval.json").write_text(json.dumps({
+        "summary": {
+            "provider": "gemini",
+            "model": "gemini-2.0-flash",
+            "n_labels": 1,
+            "n_model_hits": 1,
+            "n_matched": 0,
+            "n_label_only": 0,
+            "n_model_only": 1,
+        },
+        "model_only": [{"model_visual": 8}],
+        "label_only": [],
+        "matched": [],
+        "patterns": {},
+    }))
+
+    monkeypatch.setenv("MODEL_PROVIDER", "gemini")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-3.5-flash")
+    monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+    cfg.get_settings.cache_clear()
+    try:
+        assert _load_all_reports([tmp_path]) == []
+    finally:
+        cfg.get_settings.cache_clear()
+
+
+def test_normalize_and_aggregate_mixed_old_new_schemas():
+    from gopro_garmin_pipeline.prompt_eval import (
+        _aggregate_reports,
+        _normalize_report,
+    )
+
+    old = _normalize_report({
+        "summary": {
+            "n_labels": 2,
+            "n_gemini_hits": 3,
+            "n_matched": 1,
+            "n_label_only": 1,
+            "n_gemini_only": 2,
+        },
+        "label_only": [{"label_type": "scenery"}],
+        "gemini_only": [
+            {"gemini_visual": 9, "gemini_action": 1},
+            {"gemini_visual": 4, "gemini_action": 1},
+        ],
+        "matched": [],
+        "patterns": {"avg_gemini_only_scores": {"visual": 6.5, "action": 1}},
+    })
+    new = {
+        "summary": {
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "n_labels": 1,
+            "n_model_hits": 1,
+            "n_matched": 1,
+            "n_label_only": 0,
+            "n_model_only": 0,
+        },
+        "label_only": [],
+        "model_only": [],
+        "matched": [{"source": "both", "model_visual": 7}],
+        "patterns": {},
+    }
+    agg = _aggregate_reports([old, new])
+    assert agg["n_rides"] == 2
+    assert agg["n_labels"] == 3
+    assert agg["n_model_hits"] == 4
+    assert agg["n_matched"] == 2
+    assert agg["n_model_only"] == 2
+    assert agg["all_model_only"][0]["model_visual"] == 9
+    assert "gemini_only" not in old

--- a/tests/test_model_adapters.py
+++ b/tests/test_model_adapters.py
@@ -13,12 +13,16 @@ from gopro_garmin_pipeline.gemini_scan import _clip_cache_key, _model_fingerprin
 from gopro_garmin_pipeline.models import (
     VISION_SOURCES,
     GeminiAdapter,
+    LocalOpenAIAdapter,
     OpenAIAdapter,
     cache_dir_name,
     get_model_adapter,
     provider_api_key,
 )
 from gopro_garmin_pipeline.models.base import ClipRubric, CoarseFrameBatch, FrameScore
+from gopro_garmin_pipeline.models.local_vlm import (
+    _reset_local_request_semaphore_for_tests,
+)
 
 
 # ─── Factory / config ─────────────────────────────────────────
@@ -28,6 +32,21 @@ def test_provider_api_key_selects_by_model_provider():
     assert provider_api_key(g) == "gk"
     o = Settings(_env_file=None, model_provider="openai", gemini_api_key="gk", openai_api_key="ok")
     assert provider_api_key(o) == "ok"
+    ready = Settings(
+        _env_file=None,
+        model_provider="local",
+        local_base_url="http://localhost:8080/v1",
+        local_model="qwen2.5-vl",
+        local_api_key="local",
+    )
+    assert provider_api_key(ready) == "local"
+    incomplete = Settings(
+        _env_file=None,
+        model_provider="local",
+        local_base_url="http://localhost:8080/v1",
+        local_model="",
+    )
+    assert provider_api_key(incomplete) == ""
 
 
 def test_get_model_adapter_gemini():
@@ -55,6 +74,39 @@ def test_get_model_adapter_openai():
     assert adapter.model_id == "gpt-4.1-mini"
 
 
+def test_get_model_adapter_local():
+    _reset_local_request_semaphore_for_tests()
+    s = Settings(
+        _env_file=None,
+        model_provider="local",
+        local_base_url="http://localhost:8080/v1",
+        local_model="mlx-community/Qwen2.5-VL-3B",
+        local_api_key="local",
+        local_max_concurrency=1,
+        local_timeout_seconds=600,
+    )
+    with patch("openai.OpenAI") as OpenAI:
+        OpenAI.return_value = MagicMock()
+        adapter = get_model_adapter(s)
+    assert adapter.name == "local"
+    assert adapter.model_id == "mlx-community/Qwen2.5-VL-3B"
+    OpenAI.assert_called_once()
+    kwargs = OpenAI.call_args.kwargs
+    assert kwargs["base_url"] == "http://localhost:8080/v1"
+    assert kwargs["timeout"] == 600.0
+
+
+def test_get_model_adapter_local_requires_model():
+    s = Settings(
+        _env_file=None,
+        model_provider="local",
+        local_base_url="http://localhost:8080/v1",
+        local_model="",
+    )
+    with pytest.raises(ValueError, match="LOCAL_MODEL"):
+        get_model_adapter(s)
+
+
 def test_get_model_adapter_unknown_raises():
     s = Settings(_env_file=None, model_provider="anthropic", gemini_api_key="x")
     with pytest.raises(ValueError, match="Unknown MODEL_PROVIDER"):
@@ -64,6 +116,7 @@ def test_get_model_adapter_unknown_raises():
 def test_cache_dir_name():
     assert cache_dir_name("gemini") == ".gemini_cache"
     assert cache_dir_name("openai") == ".openai_cache"
+    assert cache_dir_name("local") == ".local_cache"
 
 
 # ─── Cache keys ───────────────────────────────────────────────
@@ -86,6 +139,12 @@ def test_openai_cache_key_includes_model_fingerprint():
     other = _clip_cache_key("GX010346.MP4", provider="openai", model_id="gpt-5-mini")
     assert other != key
     assert f"m{_model_fingerprint('gpt-5-mini')}" in other
+
+
+def test_local_cache_key_includes_model_fingerprint():
+    fp = _model_fingerprint("qwen2.5-vl")
+    key = _clip_cache_key("GX010346.MP4", provider="local", model_id="qwen2.5-vl")
+    assert key == f"GX010346_v10_m{fp}.json"
 
 
 # ─── Transient errors ─────────────────────────────────────────
@@ -121,6 +180,46 @@ def test_openai_is_transient_error():
     assert adapter.is_transient_error(FakeServer("backend error"))
     assert adapter.is_transient_error(Exception("connection Timeout"))
     assert not adapter.is_transient_error(FakeBadRequest("bad request"))
+
+
+def test_local_is_transient_error_skips_connection_refusal():
+    adapter = object.__new__(LocalOpenAIAdapter)
+
+    class FakeTimeout(Exception):
+        pass
+
+    class FakeServer(Exception):
+        status_code = 503
+
+    class FakeRateLimit(Exception):
+        status_code = 429
+
+    assert not adapter.is_transient_error(
+        ConnectionError("Local VLM unreachable at http://localhost:8080/v1")
+    )
+    assert not adapter.is_transient_error(Exception("Connection refused"))
+    assert not adapter.is_transient_error(Exception("Failed to connect to localhost"))
+    assert adapter.is_transient_error(FakeTimeout("Request Timeout"))
+    assert adapter.is_transient_error(FakeServer("backend error"))
+    assert adapter.is_transient_error(FakeRateLimit("rate limited"))
+
+
+def test_local_is_transient_error_skips_permanent_model_configuration_errors():
+    adapter = object.__new__(LocalOpenAIAdapter)
+
+    class FakeLoadFailure(Exception):
+        status_code = 500
+
+    class FakeNotFound(Exception):
+        status_code = 404
+
+    assert not adapter.is_transient_error(
+        FakeLoadFailure(
+            "Failed to load model: Repo id must use alphanumeric chars: '<your-vlm>'"
+        )
+    )
+    assert not adapter.is_transient_error(FakeNotFound("model not found"))
+    assert not adapter.is_transient_error(Exception("repository not found"))
 
 
 def test_call_with_retry_uses_adapter_transient(monkeypatch):
@@ -275,6 +374,176 @@ def test_gemini_score_frames_parses_list():
     assert out[0]["frame_index"] == 1
 
 
+# ─── Local OpenAI-compatible adapter ──────────────────────────
+
+def _local_adapter_with_client(client) -> LocalOpenAIAdapter:
+    _reset_local_request_semaphore_for_tests()
+    adapter = object.__new__(LocalOpenAIAdapter)
+    adapter.model_id = "qwen2.5-vl"
+    adapter.base_url = "http://localhost:8080/v1"
+    adapter._timeout = 600.0
+    adapter._semaphore = __import__(
+        "gopro_garmin_pipeline.models.local_vlm", fromlist=["_get_local_request_semaphore"]
+    )._get_local_request_semaphore(1)
+    adapter._client = client
+    return adapter
+
+
+def _chat_response(content: str):
+    return MagicMock(
+        choices=[MagicMock(message=MagicMock(content=content))],
+    )
+
+
+def test_local_score_frames_uses_json_schema_response_format():
+    client = MagicMock()
+    payload = {
+        "frames": [{
+            "frame_index": 0, "visual": 5, "action": 3,
+            "clip_type": "landmark", "crop_x": 50, "reason": "bridge",
+        }],
+    }
+    client.chat.completions.create.return_value = _chat_response(json.dumps(payload))
+    adapter = _local_adapter_with_client(client)
+
+    out = adapter.score_frames(images=[b"\xff\xd8fake"], system="sys", user="user")
+    assert out[0]["frame_index"] == 0
+    assert out[0]["visual"] == 5
+
+    kwargs = client.chat.completions.create.call_args.kwargs
+    assert "response_format" in kwargs
+    assert kwargs["response_format"]["type"] == "json_schema"
+    assert kwargs["response_format"]["json_schema"]["name"] == "coarse_frame_batch"
+    messages = kwargs["messages"]
+    assert messages[0]["role"] == "system"
+    user_content = messages[1]["content"]
+    assert any(p.get("type") == "image_url" for p in user_content)
+    assert any(p.get("type") == "text" for p in user_content)
+
+
+def test_local_score_clip_rubric_structured():
+    client = MagicMock()
+    payload = {
+        "light": 8, "composition": 7, "motion": 9, "scenery": 6, "subject": 9,
+        "peak_offset": 0.5, "clip_type": "action", "crop_x": 50, "reason": "sprint",
+    }
+    client.chat.completions.create.return_value = _chat_response(json.dumps(payload))
+    adapter = _local_adapter_with_client(client)
+
+    out = adapter.score_clip_rubric(images=[b"x"], system="sys", user="user")
+    assert out["motion"] == 9
+    assert out["clip_type"] == "action"
+
+
+def test_local_complete_json_narrative_and_eval():
+    client = MagicMock()
+    client.chat.completions.create.return_value = _chat_response(
+        json.dumps({"indices": [0, 5, 3]}),
+    )
+    adapter = _local_adapter_with_client(client)
+    assert adapter.complete_json(prompt="pick clips") == [0, 5, 3]
+
+    client.chat.completions.create.return_value = _chat_response(
+        json.dumps({"analysis": "over-scores tunnels", "prompt_changes": []}),
+    )
+    out = adapter.complete_json(prompt="eval", system="you are an expert")
+    assert out["analysis"] == "over-scores tunnels"
+
+
+def test_local_falls_back_when_structured_format_rejected():
+    client = MagicMock()
+
+    class UnsupportedFormat(Exception):
+        status_code = 400
+
+        def __str__(self):
+            return "Unsupported response_format type: 'json_schema'"
+
+    client.chat.completions.create.side_effect = [
+        UnsupportedFormat(),
+        _chat_response(json.dumps([
+            {"frame_index": 2, "visual": 4, "action": 4, "clip_type": "x", "crop_x": 50, "reason": "y"},
+        ])),
+    ]
+    adapter = _local_adapter_with_client(client)
+
+    out = adapter.score_frames(images=[b"x"], system="sys", user="user")
+    assert out[0]["frame_index"] == 2
+    assert client.chat.completions.create.call_count == 2
+    second_kwargs = client.chat.completions.create.call_args_list[1].kwargs
+    assert "response_format" not in second_kwargs
+
+
+def test_local_invalid_freeform_raises_not_empty():
+    client = MagicMock()
+
+    class UnsupportedFormat(Exception):
+        status_code = 400
+
+        def __str__(self):
+            return "Unsupported response_format type: 'json_schema'"
+
+    client.chat.completions.create.side_effect = [
+        UnsupportedFormat(),
+        _chat_response("sorry, I cannot help with that"),
+    ]
+    adapter = _local_adapter_with_client(client)
+
+    with pytest.raises(ValueError, match="unparseable|expected"):
+        adapter.score_frames(images=[b"x"], system="sys", user="user")
+
+
+def test_local_wrong_shape_fine_pass_raises():
+    client = MagicMock()
+
+    class UnsupportedFormat(Exception):
+        status_code = 400
+
+        def __str__(self):
+            return "Unsupported response_format type: 'json_schema'"
+
+    client.chat.completions.create.side_effect = [
+        UnsupportedFormat(),
+        _chat_response("[]"),
+    ]
+    adapter = _local_adapter_with_client(client)
+
+    with pytest.raises(ValueError, match="fine pass"):
+        adapter.score_clip_rubric(images=[b"x"], system="sys", user="user")
+
+
+def test_local_connection_refused_raises_clear_error():
+    client = MagicMock()
+    client.chat.completions.create.side_effect = Exception("Connection refused")
+    adapter = _local_adapter_with_client(client)
+
+    with pytest.raises(ConnectionError, match="Local VLM unreachable"):
+        adapter.score_frames(images=[b"x"], system="sys", user="user")
+
+
+def test_local_shared_semaphore_across_adapter_instances():
+    """Two adapters must share one process-wide semaphore."""
+    _reset_local_request_semaphore_for_tests()
+    from gopro_garmin_pipeline.models import local_vlm as lo
+
+    with patch("openai.OpenAI") as OpenAI:
+        OpenAI.return_value = MagicMock()
+        a = LocalOpenAIAdapter(
+            base_url="http://localhost:8080/v1",
+            api_key="local",
+            model="m1",
+            max_concurrency=1,
+        )
+        b = LocalOpenAIAdapter(
+            base_url="http://localhost:8080/v1",
+            api_key="local",
+            model="m2",
+            max_concurrency=1,
+        )
+    assert a._semaphore is b._semaphore
+    assert lo._LOCAL_SEMAPHORE_LIMIT == 1
+
+
 # ─── Downstream compat ────────────────────────────────────────
 
 def test_learned_ranker_has_gemini_true_for_openai():
@@ -301,7 +570,30 @@ def test_learned_ranker_has_gemini_false_without_vision():
 
 
 def test_vision_sources_constant():
-    assert VISION_SOURCES == frozenset({"gemini", "openai"})
+    assert VISION_SOURCES == frozenset({"gemini", "openai", "local"})
+
+
+def test_learned_ranker_has_gemini_true_for_local():
+    from gopro_garmin_pipeline.learned_ranker import _extract_features
+
+    feats = _extract_features({
+        "score": 7.0,
+        "sources": ["local", "telemetry"],
+        "notes": "",
+        "rubric": {"composition": 8, "scenery": 7, "motion": 6, "subject": 5},
+    })
+    assert feats["has_gemini"] == 1.0
+
+
+def test_active_model_id_local():
+    from gopro_garmin_pipeline.prompt_eval import _active_model_id
+
+    s = Settings(
+        _env_file=None,
+        model_provider="local",
+        local_model="mlx-community/Qwen2.5-VL-3B",
+    )
+    assert _active_model_id(s) == "mlx-community/Qwen2.5-VL-3B"
 
 
 def test_hits_to_segments_uses_provider_identity():

--- a/uv.lock
+++ b/uv.lock
@@ -401,9 +401,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "curl-cffi", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "ua-generator", marker = "python_full_version < '3.12'" },
+    { name = "curl-cffi" },
+    { name = "requests" },
+    { name = "ua-generator" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/bf/ec89102470c240fd1b0877f18f3b5039466da3e6af8f81dc537147b567ab/garminconnect-0.3.2.tar.gz", hash = "sha256:ca9d813139cb5f81cd6fc90236a225608e7e13acd7b1034170b0facfdd072d9a", size = 51111, upload-time = "2026-04-11T09:22:05.987Z" }
 wheels = [
@@ -423,9 +423,9 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "curl-cffi", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "ua-generator", marker = "python_full_version >= '3.12'" },
+    { name = "curl-cffi" },
+    { name = "requests" },
+    { name = "ua-generator" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/d9/7ad240d86453de083f0c460ee328e8209232d9d0ee099dcf49439d90be7a/garminconnect-0.3.3.tar.gz", hash = "sha256:f608193d7a90079fa1fd1d86e8d10e88b871b6ab2500372a9dc48358f8c2d386", size = 52234, upload-time = "2026-04-22T12:57:24.79Z" }
 wheels = [
@@ -612,6 +612,92 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -822,6 +908,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/9c/c531f2293b91265d8b48e9b329f54fdd7ffae73cb4134ea10cca4237e9cc/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0", size = 15798374, upload-time = "2026-05-18T23:37:02.674Z" },
     { url = "https://files.pythonhosted.org/packages/1a/b0/413077f6b1153ed3cba361401c6783bbad6114804a000cc22eb71c13e190/numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02", size = 16747286, upload-time = "2026-05-18T23:37:06.327Z" },
     { url = "https://files.pythonhosted.org/packages/15/ce/e5ec180bc41812edcd8daeb8639d205622c0e8c02259d8ab25a0201b3c2a/numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73", size = 12504263, upload-time = "2026-05-18T23:37:09.715Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
 ]
 
 [[package]]
@@ -1337,6 +1442,7 @@ dependencies = [
     { name = "garminconnect", version = "0.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "google-genai" },
     { name = "numpy" },
+    { name = "openai" },
     { name = "pillow" },
     { name = "pydantic-settings" },
     { name = "requests" },
@@ -1357,6 +1463,7 @@ requires-dist = [
     { name = "garminconnect", specifier = ">=0.3.0" },
     { name = "google-genai", specifier = ">=1.0" },
     { name = "numpy", specifier = ">=1.26.0" },
+    { name = "openai", specifier = ">=1.66.0" },
     { name = "pillow", specifier = ">=10.0.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
@@ -1619,6 +1726,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/ba/1f744cdc819428fc6b5084ec34d9b30660f6f9daaf70eead706e3203ec3c/toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f", size = 22253, upload-time = "2020-11-01T01:40:22.204Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/44/6f/7120676b6d73228c96e17f1f794d8ab046fc910d781c8d151120c3f1569e/toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b", size = 16588, upload-time = "2020-11-01T01:40:20.672Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.69.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/69/40407dfc835517f058b603dbf37a6df094d8582b015a51eddc988febbcb7/tqdm-4.69.0.tar.gz", hash = "sha256:700c5e85dcd5f009dd6222588a29180a193a748247a5d855b4d67db93d79a53b", size = 792569, upload-time = "2026-07-17T18:09:06.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/21/99a0cdaf54eb35e77623c41b5a2c9472ee4404bba687052791fe2aba6773/tqdm-4.69.0-py3-none-any.whl", hash = "sha256:9979978912be667a6ef21fd5d8abf54e324e63d82f7f43c360792ebc2bc4e622", size = 676680, upload-time = "2026-07-17T18:09:04.172Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- introduce a shared model adapter used by Gemini, OpenAI, and local OpenAI-compatible VLMs
- preserve Gemini as the default while isolating provider/model caches and comparison reports
- generalize the label comparison and narrative-selection paths across providers
- add reproducible GPT-4.1 mini and Qwen3-VL results for the published sample ride
- retain backward compatibility for legacy Gemini caches, reports, and CLI flags

## Findings

Using the unchanged v10 rubric on the eight labeled chapters:

| Model | Fine ratings | Matches | Visual SD | Action SD |
|---|---:|---:|---:|---:|
| Gemini 3.5 Flash | 24 | 8/9 | 1.68 | 1.27 |
| GPT-4.1 mini | 23 | 8/9 | 1.13 | 0.84 |
| Qwen3-VL 8B 3-bit | 28 | 9/9 | 1.28 | 0.54 |

Gemini produced the widest distributions. GPT compressed interesting and ordinary footage toward nearly identical scores. Qwen recognized forced fine-pass clips, including the two-second deer, but returned zero coarse-pass discoveries and compressed action scores into the 4-6 range.

The committed caches and reports let these comparisons run from `samples/2026-07-10` without video, credentials, or a local model. The write-up also documents that label timestamps are forced into the fine pass, so temporal recall is not discovery recall.

## Verification

- `pytest -q` — 76 passed
- `ruff check .`
- `pip check`
- reproduced all three committed reports from the video-free sample folder

Closes #2