### PR TITLE
Add optional per-shot color grading (--wb / --look)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,36 @@ This is basically coaching a video intern by showing them the cuts you didn't li
 
 ---
 
+## Color grading (optional)
+
+Off by default — the reel ships as-shot unless you opt in. If you lock white
+balance on the camera (e.g. 5500K on a GoPro — the right way to shoot for a
+graded cut), the pipeline can do the balancing afterward, per shot:
+
+```bash
+ride-recap process <date-folder> --wb shot                     # correction only
+ride-recap process <date-folder> --wb shot --look house        # + a shared look
+ride-recap compose-selected <sel> <dir> <fit> --wb shot --look warm-afternoon --look-strength 50
+```
+
+`--wb shot` measures each selected clip around its anchor (median of three
+frames) and neutralises it: a gentle levels stretch, white balance measured on
+near-neutral pixels only (asphalt, concrete, cloud — not a wall of canopy),
+and an exposure nudge applied as midtone gamma so highlights never clip. Light
+changes over a multi-hour ride, so the correction is per-shot — there is no
+single grade that fits hour 1 and hour 4.
+
+`--look` layers one shared creative recipe over every clip (`house`,
+`warm-afternoon`, `cool-morning`, `soft-film`, `overcast-lift`), scaled by
+`--look-strength`. Looks live in `grade.py` as small dicts — add your own.
+They lean on vibrance over saturation and pull highlights down rather than
+exposure up, because a blown sky is the one thing this footage cannot recover.
+
+The grade is applied to the footage *before* the HUD composites, so the
+overlay's white-with-black-stroke stays untouched.
+
+---
+
 ## Commands
 
 ```bash
@@ -281,6 +311,7 @@ src/gopro_garmin_pipeline/
   models/             # Gemini, OpenAI, and local OpenAI-compatible adapters
   composer.py         # Candidate generation, fusion, selection, composition
   burn_overlay.py     # The 5-element HUD, landscape + portrait
+  grade.py            # Optional per-shot correction + shared looks (--wb / --look)
   intro_outro.py      # Blur→title opener, outro recap card
   route_metadata.py   # Start / Far / Road from GPS via OSM + Overpass
   highlights.py       # Telemetry spike detection

--- a/src/gopro_garmin_pipeline/burn_overlay.py
+++ b/src/gopro_garmin_pipeline/burn_overlay.py
@@ -1037,6 +1037,7 @@ def burn_overlay(
     portrait_crop_bias: float = 0.0,
     lockup: str | None = None,
     intro_secs: float = 0.0,
+    grade: str = "",
 ) -> Path:
     """Burn telemetry overlay onto video.
 
@@ -1056,6 +1057,8 @@ def burn_overlay(
         ride: Pre-parsed RideData to avoid re-parsing FIT.
         encode_preset: "preview" (VideoToolbox, fast) or "master"
             (libx264, high quality, +faststart).
+        grade: ffmpeg filter chain from grade.build_filter(), applied to the
+            footage before the HUD composites. Empty string = no grade.
     """
     video_path = Path(video_path)
     output_path = Path(output_path)
@@ -1126,6 +1129,13 @@ def burn_overlay(
         base = "[base]"
     else:
         base = "[0:v]"
+
+    # Grade the footage *before* the HUD composites, never after: the overlay's
+    # white-with-black-stroke is a fixed design language and must not inherit the
+    # look's contrast curve or colour cast.
+    if grade:
+        filters.append(f"{base}{grade}[graded]")
+        base = "[graded]"
 
     if intro_secs > 0:
         # Blur→clear: crossfade a gaussian-blurred copy into the sharp copy

--- a/src/gopro_garmin_pipeline/cli.py
+++ b/src/gopro_garmin_pipeline/cli.py
@@ -14,6 +14,34 @@ from .gopro_meta import extract_all
 from .highlights import HighlightConfig, detect_highlights
 
 
+def _grade_options(fn):
+    """Shared colour-grade flags for process / compose / compose-selected.
+
+    Defaults leave footage untouched, so adding these to a command changes
+    nothing until the user opts in.
+    """
+    from .grade import LOOKS
+
+    fn = click.option(
+        "--look", "grade_look", default="none",
+        type=click.Choice(sorted(LOOKS), case_sensitive=False),
+        help="Shared creative look applied to every clip. Default: none.",
+    )(fn)
+    fn = click.option(
+        "--look-strength", "grade_strength", default=35, type=click.IntRange(0, 100),
+        help="Percent strength of --look. 35 is a house look; past ~50 it "
+             "starts reading as a filter. Default: 35.",
+    )(fn)
+    fn = click.option(
+        "--wb", "grade_wb", default="off",
+        type=click.Choice(["shot", "off"], case_sensitive=False),
+        help="Per-shot correction: 'shot' measures and balances each clip on "
+             "its own (levels, white balance, exposure), 'off' skips it. "
+             "Default: off.",
+    )(fn)
+    return fn
+
+
 _CREW_CACHE_PATH = Path.home() / ".ride_recap_cache" / "last_crew.txt"
 
 
@@ -378,6 +406,7 @@ def burn(video_path: Path, fit_file: Path, output: Path | None, offset: float,
 @click.option("--lockup", default=None,
               help="Full in-segment bottom-band string. Overrides origin/road for "
               "the per-clip HUD only; recap card still uses --origin/--road/--crew.")
+@_grade_options
 def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_dir: Path | None,
             offset: float, no_auto_sync: bool,
             landscape_duration: float, portrait_duration: float,
@@ -385,7 +414,9 @@ def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_di
             landscape_only: bool, strava_activity: int | None,
             preview: bool, skip_gemini: bool, skip_narrative: bool, no_upload: bool,
             origin: str | None, destination: str | None, subtitle: str | None,
-            road: str | None, crew: str | None, lockup: str | None):
+            road: str | None, crew: str | None, lockup: str | None,
+            grade_look: str = "none", grade_strength: int = 35,
+            grade_wb: str = "off"):
     """Compose highlight videos from ride telemetry + optional labels.
 
     VIDEO_DIR: Directory containing GoPro .mp4 files
@@ -443,6 +474,9 @@ def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_di
         road=fields["road"],
         crew=fields["crew"],
         lockup=lockup,
+        grade_look=grade_look,
+        grade_strength=grade_strength / 100,
+        grade_wb=grade_wb,
     )
     with keep_system_awake() as awake:
         if awake:
@@ -500,6 +534,7 @@ def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_di
               help="Anchor the recap end pin at the farthest point reached (the ride "
               "apex/turnaround) instead of where the ride ended. Use when you trained "
               "or drove home from a different town than the real destination.")
+@_grade_options
 def process(date_folder: Path, offset: float, no_auto_sync: bool,
             strava_activity: int | None,
             landscape_duration: float, portrait_duration: float,
@@ -507,7 +542,9 @@ def process(date_folder: Path, offset: float, no_auto_sync: bool,
             skip_gemini: bool, skip_review: bool, no_upload: bool, port: int,
             origin: str | None, destination: str | None, subtitle: str | None,
             road: str | None, crew: str | None, lockup: str | None,
-            far_pin: bool = False):
+            far_pin: bool = False,
+            grade_look: str = "none", grade_strength: int = 35,
+            grade_wb: str = "off"):
     """Full pipeline: detect → review → compose highlight videos.
 
     DATE_FOLDER: Date folder (e.g. data/raw/2026-04-11/) containing
@@ -562,6 +599,8 @@ def process(date_folder: Path, offset: float, no_auto_sync: bool,
             origin=fields["origin"], destination=fields["destination"],
             subtitle=fields["subtitle"], road=fields["road"],
             crew=fields["crew"], lockup=lockup, far_pin=far_pin,
+            grade_look=grade_look, grade_strength=grade_strength,
+            grade_wb=grade_wb,
         )
 
 
@@ -574,7 +613,9 @@ def _process_body(date_folder: Path, offset: float, no_auto_sync: bool,
                   origin: str | None = None, destination: str | None = None,
                   subtitle: str | None = None, road: str | None = None,
                   crew: str | None = None, lockup: str | None = None,
-                  far_pin: bool = False):
+                  far_pin: bool = False,
+                  grade_look: str = "none", grade_strength: int = 35,
+                  grade_wb: str = "off"):
     """Body of `process` — extracted so caffeinate wraps the whole run."""
     from .composer import ComposerConfig, generate_all_candidates, compose_highlight
     from .gpmf_sync import resolve_offset
@@ -628,6 +669,9 @@ def _process_body(date_folder: Path, offset: float, no_auto_sync: bool,
         crew=crew,
         lockup=lockup,
         far_pin=far_pin,
+        grade_look=grade_look,
+        grade_strength=grade_strength / 100,
+        grade_wb=grade_wb,
     )
 
     # Step 1: Generate candidates
@@ -824,12 +868,15 @@ def review_candidates(video_dir: Path, fit_file: Path, labels_file: Path | None,
               help="Anchor the recap end pin at the farthest point reached (the ride "
               "apex/turnaround) instead of where the ride ended. Use when you trained "
               "or drove home from a different town than the real destination.")
+@_grade_options
 def compose_selected(selections_file: Path, video_dir: Path, fit_file: Path,
                      output_dir: Path | None, offset: float, no_auto_sync: bool,
                      layout: str, preview: bool, trim: float,
                      origin: str | None, destination: str | None, subtitle: str | None,
                      road: str | None, crew: str | None, lockup: str | None,
-                     far_pin: bool = False):
+                     far_pin: bool = False,
+                     grade_look: str = "none", grade_strength: int = 35,
+                     grade_wb: str = "off"):
     """Compose a highlight video from hand-picked candidate selections.
 
     SELECTIONS_FILE: moments.json or selected_candidates.json
@@ -867,6 +914,8 @@ def compose_selected(selections_file: Path, video_dir: Path, fit_file: Path,
             origin=fields["origin"], destination=fields["destination"],
             subtitle=fields["subtitle"], road=fields["road"],
             crew=fields["crew"], lockup=lockup, far_pin=far_pin,
+            grade_look=grade_look, grade_strength=grade_strength / 100,
+            grade_wb=grade_wb,
         )
     click.echo(f"\nDone! {result}")
 

--- a/src/gopro_garmin_pipeline/composer.py
+++ b/src/gopro_garmin_pipeline/composer.py
@@ -204,6 +204,12 @@ class ComposerConfig:
     # then train/drive home from a different town.
     far_pin: bool = False
 
+    # Colour grade (see grade.py). The defaults leave footage untouched, so
+    # grading is strictly opt-in.
+    grade_look: str = "none"
+    grade_strength: float = 0.35
+    grade_wb: str = "off"  # "shot" | "off"
+
     @property
     def pad_before(self) -> float:
         """Seconds before the candidate midpoint — 50% of segment duration."""
@@ -1571,6 +1577,47 @@ def _version_stamp(video_dir: Path) -> str:
     return f"{video_dir.name.replace('-', '')}_{datetime.now().strftime('%H%M%S')}"
 
 
+def build_segment_grades(
+    shots: list[tuple[str, float]],
+    video_dir: Path,
+    look: str,
+    strength: float,
+    wb: str,
+) -> dict[int, str]:
+    """Measure every shot's balance once and return {index: ffmpeg filter chain}.
+
+    `shots` is [(clip_name, anchor_video_secs), ...] — the two paths into the
+    burn carry segments as objects and as dicts, so this takes the flattened
+    form both can produce.
+
+    Measurement samples a few frames around each segment's anchor, so this
+    costs a handful of cheap ffmpeg seeks per clip in the cut rather than
+    anything per-frame.
+
+    Returns an empty dict when grading is off, which the burn loop reads as
+    "pass no filter".
+    """
+    from .grade import build_filter, measure_shot
+
+    if look == "none" and wb == "off":
+        return {}
+
+    balances: dict[int, object] = {}
+    if wb == "shot":
+        print(f"\nMeasuring shot balance for {len(shots)} segments...")
+        for i, (clip_name, anchor) in enumerate(shots):
+            balances[i] = measure_shot(video_dir / clip_name, anchor)
+
+    grades = {
+        i: build_filter(balances.get(i), look=look, strength=strength)
+        for i in range(len(shots))
+    }
+    active = sum(1 for v in grades.values() if v)
+    print(f"  Grade: look={look} @ {strength:.0%}, wb={wb} "
+          f"({active}/{len(shots)} segments)")
+    return grades
+
+
 def compose_from_selections(
     selections_path: Path,
     video_dir: Path,
@@ -1592,6 +1639,9 @@ def compose_from_selections(
     subtitle: str | None = None,
     lockup: str | None = None,
     far_pin: bool = False,
+    grade_look: str = "none",
+    grade_strength: float = 0.35,
+    grade_wb: str = "off",
 ) -> Path:
     """Compose a highlight video from a selections file.
 
@@ -1658,6 +1708,13 @@ def compose_from_selections(
     adjusted_clips = extract_all(video_dir)
     clip_by_name = {c.path.name: c for c in adjusted_clips}
 
+    grades = build_segment_grades(
+        [(s["clip_name"],
+          s.get("anchor_video_secs") or (s["video_start"] + s["video_end"]) / 2)
+         for s in segments],
+        video_dir, grade_look, grade_strength, grade_wb,
+    )
+
     clips = []
     for i, seg in enumerate(segments):
         notes = seg.get("notes", "")[:60]
@@ -1720,6 +1777,7 @@ def compose_from_selections(
             encode_preset=encode_preset,
             portrait_crop_bias=float(seg.get("portrait_crop_bias", 0.0)),
             intro_secs=seg_intro,
+            grade=grades.get(i, ""),
         )
         clips.append(out)
 
@@ -2034,6 +2092,11 @@ def compose_highlight(
         outro_extra = (
             config.outro_lead_in_secs if config.include_outro else 0.0
         )
+        grades = build_segment_grades(
+            [(s.clip_name, s.anchor_video_secs or (s.video_start + s.video_end) / 2)
+             for s in segs],
+            video_dir, config.grade_look, config.grade_strength, config.grade_wb,
+        )
         for i, seg in enumerate(segs):
             print(f"\n[{i+1}/{len(segs)}] {seg.label.get('notes', '')[:60]}")
             source = video_dir / seg.clip_name
@@ -2078,6 +2141,7 @@ def compose_highlight(
                 encode_preset=encode_preset,
                 portrait_crop_bias=seg.portrait_crop_bias,
                 intro_secs=intro_secs,
+                grade=grades.get(i, ""),
             )
             burned.append(out)
         return burned

--- a/src/gopro_garmin_pipeline/grade.py
+++ b/src/gopro_garmin_pipeline/grade.py
@@ -1,0 +1,249 @@
+"""Two-layer colour grading: per-shot correction, then a shared look.
+
+Pass 1 (correct) measures each shot on its own and neutralises it: black/white
+anchors from the luma histogram, neutral-pixel white balance (luma-normalised),
+and a highlight-safe gamma nudge toward a shared middle. Pass 2 (look) is one
+shared creative recipe applied identically to every shot, scaled by a strength
+factor.
+
+This assumes the camera shot with white balance LOCKED (e.g. 5500K on a GoPro),
+so it did not balance anything per frame. That is the right way to shoot for a
+graded cut — every clip carries one known transform instead of a live,
+unrecorded, drifting one — but it means the correction has to happen here.
+Light changes over a multi-hour ride, so the correction is per-shot, never
+one grade over the whole ride.
+
+    from .grade import measure_shot, build_filter
+    bal = measure_shot("GX010406.MP4", at_secs=812.0)
+    vf  = build_filter(bal, look="house", strength=0.35)
+"""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+# WB gains beyond this are almost never a real cast — they are a scene that
+# is genuinely dominated by one colour (a wall of summer canopy, a glass tower
+# against sky). Clamping keeps the correction from eating the subject. The gains
+# are measured on near-neutral pixels only (asphalt, concrete, cloud) and applied
+# luma-normalised, so the clamp can sit tight.
+_WB_CLAMP = (0.93, 1.07)
+_NEUTRAL_CHROMA = 0.12   # max (channel spread) for a pixel to count as neutral
+_NEUTRAL_MIN = 500       # fall back to the full midtone mask below this many
+_MID_TARGET = 0.40   # median luma the exposure nudge aims for
+_EV_DAMP = 0.6       # correct only this fraction of the way to the target
+_EV_CLAMP = 0.6      # stops
+_LUMA = (0.2126, 0.7152, 0.0722)
+
+# Recipes are written at full strength and land scaled by `strength`. They lean on
+# vibrance rather than saturation (asphalt and skin stay put while canopy separates)
+# and pull highlights down rather than pushing exposure up, because a blown sky is
+# the one thing in this footage that cannot be recovered.
+LOOKS: dict[str, dict[str, float]] = {
+    "none": {},
+    "house": {"contrast": 16, "vib": 20, "highlights": -12, "shadows": 5},
+    "warm-afternoon": {"temp": 22, "tint": 4, "exposure": 0.10, "contrast": 12,
+                       "vib": 16, "highlights": -14},
+    "cool-morning": {"temp": -16, "tint": -4, "contrast": 14, "vib": 18, "shadows": -5},
+    "soft-film": {"fade": 24, "contrast": 12, "sat": -8, "temp": 7, "shadows": 9},
+    "overcast-lift": {"exposure": 0.22, "contrast": 18, "vib": 26, "temp": 10,
+                      "shadows": 13, "highlights": -18},
+}
+
+
+@dataclass(frozen=True)
+class ShotBalance:
+    """Per-shot correction, median-combined from a few frames around the anchor."""
+    b: float    # black anchor (luma)
+    w: float    # white anchor (luma)
+    gr: float   # neutral-pixel WB gain applied to red
+    gb: float   # neutral-pixel WB gain applied to blue
+    ev: float   # exposure correction, stops
+    med: float = 0.35   # median luma the ev was measured against (drives the gamma)
+
+
+NEUTRAL = ShotBalance(b=0.0, w=1.0, gr=1.0, gb=1.0, ev=0.0)
+
+
+def _measure_frame(video_path: Path, at_secs: float):
+    """Stats for one frame: (b, w, gr, gb, med), or None if it cannot be decoded."""
+    import io
+
+    import numpy as np
+    from PIL import Image
+
+    proc = subprocess.run(
+        ["ffmpeg", "-v", "error",
+         "-ss", f"{max(0.0, at_secs):.3f}", "-i", str(video_path),
+         "-frames:v", "1", "-vf", "scale=640:-1",
+         "-f", "image2pipe", "-vcodec", "png", "pipe:1"],
+        capture_output=True, check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        return None
+
+    im = np.asarray(Image.open(io.BytesIO(proc.stdout)).convert("RGB"),
+                    dtype=np.float32) / 255.0
+    luma = np.array(_LUMA, dtype=np.float32)
+
+    lum = im @ luma
+    b = float(np.percentile(lum, 0.5))
+    w = float(max(np.percentile(lum, 99.7), b + 0.05))
+
+    lv = np.clip((im - b) / (w - b), 0, 1)
+    l2 = lv @ luma
+    mid = (l2 > 0.15) & (l2 < 0.85)
+    if not mid.any():           # near-black or blown frame: skip WB, keep levels
+        return b, w, 1.0, 1.0, 0.35
+
+    # WB is measured on near-neutral pixels only (asphalt, concrete, cloud).
+    # Raw grey-world over the midtones reads a wall of canopy as a green cast
+    # and slams both gains into the clamp, which is a brightness lift and a
+    # magenta shift, not a correction.
+    spread = lv.max(axis=2) - lv.min(axis=2)
+    neutral = mid & (spread < _NEUTRAL_CHROMA)
+    sample = lv[neutral] if int(neutral.sum()) >= _NEUTRAL_MIN else lv[mid]
+    means = sample.mean(axis=0)
+    gr = float(np.clip(means[1] / max(means[0], 1e-4), *_WB_CLAMP))
+    gb = float(np.clip(means[1] / max(means[2], 1e-4), *_WB_CLAMP))
+
+    med = float(np.median(np.clip(lv * [gr, 1.0, gb], 0, 1) @ luma))
+    return b, w, gr, gb, med
+
+
+def measure_shot(video_path: str | Path, at_secs: float = 0.0) -> ShotBalance:
+    """Measure `video_path` around `at_secs` and return its correction.
+
+    Samples three frames (anchor ±1s) and median-combines the stats, so one
+    moment of shade or a passing truck cannot decide the grade for the whole cut.
+
+    Reads from the master file rather than a low-res proxy: the proxy is 8-bit
+    H.264 and would hide the shadow noise and banding the correction has to
+    respect. Falls back to NEUTRAL if no frame can be decoded, so a bad seek
+    degrades to "ungraded" rather than killing the burn.
+    """
+    import numpy as np
+
+    times = [t for t in (at_secs - 1.0, at_secs, at_secs + 1.0) if t >= 0.0]
+    stats = [s for s in (_measure_frame(Path(video_path), t) for t in times)
+             if s is not None]
+    if not stats:
+        print(f"  Warning: grade could not sample {Path(video_path).name} "
+              f"@{at_secs:.1f}s — leaving this shot uncorrected")
+        return NEUTRAL
+
+    b, w, gr, gb, med = (float(np.median(v)) for v in zip(*stats))
+    ev = float(np.clip(_EV_DAMP * np.log2(_MID_TARGET / max(med, 0.05)),
+                       -_EV_CLAMP, _EV_CLAMP))
+    return ShotBalance(round(b, 4), round(w, 4), round(gr, 4), round(gb, 4),
+                       round(ev, 3), round(med, 4))
+
+
+def scaled_look(look: str, strength: float) -> dict[str, float]:
+    """The look recipe with every term scaled. Each term is written so 0 is identity,
+    so one multiplier interpolates the whole pass from untouched to full."""
+    recipe = LOOKS.get(look.lower().replace(" ", "-"))
+    if recipe is None:
+        raise ValueError(f"unknown look {look!r} — choose from {', '.join(LOOKS)}")
+    return {k: v * strength for k, v in recipe.items()}
+
+
+def build_filter(
+    balance: ShotBalance | None = None,
+    look: str = "none",
+    strength: float = 0.35,
+) -> str:
+    """Build the ffmpeg filter chain for one shot. Empty string means "no grade".
+
+    Args:
+        balance: this shot's correction from measure_shot(), or None to skip
+            the per-shot pass entirely (look only).
+        look: key into LOOKS.
+        strength: 0..1 multiplier over the whole look pass.
+    """
+    parts: list[str] = []
+    L = scaled_look(look, strength)
+
+    # Levels and white balance are two separate filters on purpose.
+    #
+    # The obvious-looking trick is to fold the WB gains into colorlevels by
+    # scaling each channel's input max (imax_c = b + (w-b)/gain_c). That is
+    # algebraically right but breaks in practice: colorlevels requires every
+    # imax in [0,1], and a gain below 1 on a shot whose white anchor is near
+    # 1.0 pushes imax above 1.0, so ffmpeg aborts with "Result too large".
+    # Shots with clipped highlights (w == 1.000) hit this routinely.
+    #
+    # colorchannelmixer applies per-channel gain directly and takes values
+    # above 1, so it carries the WB and colorlevels does only the stretch —
+    # where all three channels share the same in-range anchors.
+    if balance is not None:
+        b = min(max(balance.b, 0.0), 0.94)
+        w = min(max(balance.w, b + 0.05), 1.0)
+        # Stretch only partway to the anchor, and not at all when the frame
+        # already reaches near-white: the anchor is one percentile of a few
+        # frames, and a full stretch on a hazy shot burns the sky for a
+        # contrast gain nobody asked for.
+        if w < 0.985:
+            w = w + (1.0 - w) * 0.4
+        else:
+            w = 1.0
+        if b > 5e-4 or w < 1 - 5e-4:
+            # Pin a concrete RGB format first: ffmpeg 8.1 lets colorlevels
+            # negotiate a format on 10-bit full-range masters that renders
+            # solid black whenever a black-point (imin) is set.
+            parts.append("format=gbrp16le")
+            parts.append(
+                f"colorlevels=rimin={b:.3f}:gimin={b:.3f}:bimin={b:.3f}"
+                f":rimax={w:.3f}:gimax={w:.3f}:bimax={w:.3f}"
+            )
+        if abs(balance.gr - 1.0) > 5e-4 or abs(balance.gb - 1.0) > 5e-4:
+            # Luma-normalised: WB may only trade colour, never buy brightness.
+            # Without this, a green-heavy scene that pushes both gains up
+            # applies a hidden exposure lift on top of the ev pass and clips
+            # the sky.
+            gr, gb = balance.gr, balance.gb
+            norm = _LUMA[0] * gr + _LUMA[1] + _LUMA[2] * gb
+            parts.append(
+                f"colorchannelmixer=rr={gr / norm:.4f}:gg={1 / norm:.4f}"
+                f":bb={gb / norm:.4f}"
+            )
+
+        # The shot's own exposure correction lands as a midtone gamma, which
+        # pins black and white in place: a linear `exposure` gain on a
+        # +0.4-stop shot clips every sky pixel above ~0.75, and a blown sky is
+        # the one thing this footage cannot recover. The look's exposure term
+        # stays linear below — looks are authored knowing that.
+        if abs(balance.ev) > 0.02 and 0.05 < balance.med < 0.9:
+            import math
+            target = min(max(balance.med * 2 ** balance.ev, 0.05), 0.9)
+            gamma = math.log(balance.med) / math.log(target)
+            gamma = min(max(gamma, 0.75), 1.3)
+            if abs(gamma - 1.0) > 0.01:
+                parts.append(f"eq=gamma={gamma:.3f}")
+
+    ev = L.get("exposure", 0.0)
+    if abs(ev) > 0.001:
+        parts.append(f"exposure=exposure={ev:.2f}")
+    if L.get("temp"):
+        parts.append(f"colortemperature=temperature={round(6500 - L['temp'] * 20)}")
+
+    eq = []
+    if L.get("contrast"):
+        eq.append(f"contrast={1 + L['contrast'] / 100 * 0.85:.2f}")
+    if L.get("sat"):
+        eq.append(f"saturation={1 + L['sat'] / 100:.2f}")
+    if eq:
+        parts.append("eq=" + ":".join(eq))
+
+    if L.get("vib"):
+        parts.append(f"vibrance=intensity={L['vib'] / 100:.2f}")
+
+    if L.get("shadows") or L.get("highlights") or L.get("fade"):
+        a = L.get("fade", 0.0) / 100 * 0.07
+        s = min(1.0, max(0.0, 0.25 + L.get("shadows", 0.0) / 100 * 0.09))
+        h = min(1.0, max(0.0, 0.80 + L.get("highlights", 0.0) / 100 * 0.08))
+        parts.append(f"curves=all='0/{a:.3f} 0.25/{s:.3f} 0.80/{h:.3f} 1/1'")
+
+    return ",".join(parts)

--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -1,0 +1,55 @@
+"""Pure-math tests for the colour grade filter builder (no ffmpeg needed)."""
+
+import pytest
+
+from gopro_garmin_pipeline.grade import LOOKS, NEUTRAL, ShotBalance, build_filter, scaled_look
+
+
+def test_no_grade_is_empty_string():
+    assert build_filter(None, look="none") == ""
+
+
+def test_neutral_balance_is_identity():
+    assert build_filter(NEUTRAL, look="none") == ""
+
+
+def test_correction_pins_format_before_colorlevels():
+    # ffmpeg 8.1 renders solid black if colorlevels sets a black point on
+    # 10-bit full-range input without a pinned format — the pin must survive.
+    bal = ShotBalance(b=0.02, w=0.95, gr=1.0, gb=1.0, ev=0.0, med=0.4)
+    vf = build_filter(bal, look="none")
+    assert "colorlevels" in vf
+    assert vf.index("format=gbrp16le") < vf.index("colorlevels")
+
+
+def test_wb_gains_are_luma_normalised():
+    # WB may shift colour but never brightness: the luma dot-product of the
+    # applied gains must be ~1 regardless of the measured gains.
+    bal = ShotBalance(b=0.0, w=1.0, gr=1.05, gb=1.05, ev=0.0, med=0.4)
+    vf = build_filter(bal, look="none")
+    parts = dict(kv.split("=") for kv in
+                 vf.split("colorchannelmixer=")[1].split(",")[0].split(":"))
+    luma = 0.2126 * float(parts["rr"]) + 0.7152 * float(parts["gg"]) \
+        + 0.0722 * float(parts["bb"])
+    assert abs(luma - 1.0) < 1e-3
+
+
+def test_exposure_correction_is_gamma_not_linear():
+    # The per-shot ev lands as midtone gamma (pins black/white); linear
+    # exposure is reserved for looks.
+    bal = ShotBalance(b=0.0, w=1.0, gr=1.0, gb=1.0, ev=0.4, med=0.25)
+    vf = build_filter(bal, look="none")
+    assert "eq=gamma=" in vf
+    assert "exposure" not in vf
+
+
+def test_look_scales_with_strength():
+    weak = build_filter(None, look="house", strength=0.2)
+    strong = build_filter(None, look="house", strength=0.8)
+    assert weak != strong
+    assert scaled_look("house", 0.0) == {k: 0.0 for k in LOOKS["house"]}
+
+
+def test_unknown_look_raises():
+    with pytest.raises(ValueError):
+        build_filter(None, look="teal-and-orange")


### PR DESCRIPTION
## What

Opt-in color grading for the composed reel, in two independent layers:

- **`--wb shot`** — per-shot correction. Each selected clip is measured around its anchor (median of three frames) and neutralised: softened levels stretch, white balance measured on near-neutral pixels only (asphalt/concrete/cloud, so a wall of canopy doesn't read as a green cast), and an exposure nudge applied as **midtone gamma** so highlights never clip. Light changes over a multi-hour ride, so correction is per-shot by design — there is no single grade that fits hour 1 and hour 4.
- **`--look <name> --look-strength <pct>`** — one shared creative recipe over every clip (`house`, `warm-afternoon`, `cool-morning`, `soft-film`, `overcast-lift`). Looks are small dicts in `grade.py`; add your own.

Defaults (`--wb off --look none`) leave the output byte-identical in intent to today's: grading only happens when you ask.

This assumes white balance is **locked in camera** (e.g. 5500K) — the right way to shoot for a graded cut, since every clip then carries one known transform instead of a live drifting one.

## How

- New `grade.py`: `measure_shot()` (ffmpeg frame sample + numpy stats) and `build_filter()` (pure string → ffmpeg filter chain).
- `burn_overlay()` gains a `grade` filter-chain param, injected **before** the HUD composites so the overlay's white-with-black-stroke design language is untouched.
- `composer.build_segment_grades()` measures each shot once up front; both the autonomous path (`compose_highlight`) and the reviewed path (`compose_from_selections`) use it.
- Flags wired through `process`, `compose`, and `compose-selected`.

Notable footgun handled: ffmpeg 8.1's `colorlevels` renders **solid black** on 10-bit full-range GoPro masters whenever a black point (`imin > 0`) is set, depending on format negotiation. `build_filter` pins `format=gbrp16le` immediately before `colorlevels`.

## Testing

- `tests/test_grade.py`: 7 pure-math tests (identity, format pin ordering, luma-normalised WB, gamma-not-linear exposure, look scaling).
- Full suite: 86 passed, 4 pre-existing failures in `test_model_adapters.py` (missing `openai` dep in env, unrelated).
- Validated on a real 20-clip ride at 4K: split-screen A/B (as-shot | graded) shows open shadows and richer color with no sky clipping.

## Example

```bash
ride-recap process data/raw/2026-08-01/ --wb shot --look house
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)