### PR TITLE
Pin the ruff rule set instead of inheriting its defaults

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,5 +69,13 @@ gopro_garmin_pipeline = [
 line-length = 100
 target-version = "py311"
 
+[tool.ruff.lint]
+# Pinned explicitly rather than inherited. The dev extra floats ruff, and
+# ruff 0.16 widened its default rule set — which turned a routine release
+# into 125 lint errors on an unchanged tree and a red CI on every open PR.
+# These four are the set the codebase was written against; widening it is a
+# deliberate change with its own cleanup, not something a release does for us.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
CI has been red on every open PR since ruff 0.16 shipped, with no code change to blame — see [run 30719667189](https://github.com/ianmacomber/ride-recap/actions/runs/30719667189), which fails at `Lint` before the tests ever run.

**Cause.** The dev extra floats `ruff>=0.4.0`, and `[tool.ruff]` set only `line-length` and `target-version`. With no `select`, the rule set was whatever that day's ruff considered default. 0.16 widened it, so an unchanged `main` went from clean to **125 errors** — `I001`, `S110`, `BLE001`, `UP017`, `UP037` and friends, across files nobody had touched.

Verified locally against a clean `main`:

| ruff | result |
|---|---|
| 0.15.15 | All checks passed |
| 0.16.1 | Found 125 errors |

**Fix.** Select `E4`/`E7`/`E9`/`F` explicitly — the set the codebase was written against — so a ruff release can't redefine it. Clean under both versions.

Widening the rule set may well be worth doing, but as its own change with its own cleanup, not as a side effect of a dependency release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)