### PR TITLE
Confine the signal reveal's RGB round-trip, plumb intro flags

### DIFF
--- a/src/gopro_garmin_pipeline/cli.py
+++ b/src/gopro_garmin_pipeline/cli.py
@@ -43,6 +43,28 @@ def _grade_options(fn):
     return fn
 
 
+def _intro_options(fn):
+    """Shared opening-reveal flags for process / compose / compose-selected.
+
+    These mirror `burn`'s --intro-style / --intro-reveal. Without them the
+    reel-producing commands are pinned to ComposerConfig's defaults, which is
+    every path the README actually tells people to run.
+    """
+    fn = click.option(
+        "--intro-reveal", "intro_reveal_secs", default=0.0, type=float,
+        help="Seconds for the opening footage to resolve. 0 = the style's "
+             "own default.",
+    )(fn)
+    fn = click.option(
+        "--intro-style", default=intro_styles.DEFAULT_STYLE,
+        type=click.Choice(intro_styles.STYLES),
+        help="How the footage resolves under the opening title card: "
+             + "; ".join(f"{name} — {intro_styles.describe(name)}"
+                         for name in intro_styles.STYLES),
+    )(fn)
+    return fn
+
+
 _CREW_CACHE_PATH = Path.home() / ".ride_recap_cache" / "last_crew.txt"
 
 
@@ -414,6 +436,7 @@ def burn(video_path: Path, fit_file: Path, output: Path | None, offset: float,
               help="Full in-segment bottom-band string. Overrides origin/road for "
               "the per-clip HUD only; recap card still uses --origin/--road/--crew.")
 @_grade_options
+@_intro_options
 def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_dir: Path | None,
             offset: float, no_auto_sync: bool,
             landscape_duration: float, portrait_duration: float,
@@ -422,6 +445,8 @@ def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_di
             preview: bool, skip_gemini: bool, skip_narrative: bool, no_upload: bool,
             origin: str | None, destination: str | None, subtitle: str | None,
             road: str | None, crew: str | None, lockup: str | None,
+            intro_style: str = intro_styles.DEFAULT_STYLE,
+            intro_reveal_secs: float = 0.0,
             grade_look: str = "none", grade_strength: int = 35,
             grade_wb: str = "off"):
     """Compose highlight videos from ride telemetry + optional labels.
@@ -481,6 +506,8 @@ def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_di
         road=fields["road"],
         crew=fields["crew"],
         lockup=lockup,
+        intro_style=intro_style,
+        intro_reveal_secs=intro_reveal_secs,
         grade_look=grade_look,
         grade_strength=grade_strength / 100,
         grade_wb=grade_wb,
@@ -542,6 +569,7 @@ def compose(video_dir: Path, fit_file: Path, labels_file: Path | None, output_di
               "apex/turnaround) instead of where the ride ended. Use when you trained "
               "or drove home from a different town than the real destination.")
 @_grade_options
+@_intro_options
 def process(date_folder: Path, offset: float, no_auto_sync: bool,
             strava_activity: int | None,
             landscape_duration: float, portrait_duration: float,
@@ -550,6 +578,8 @@ def process(date_folder: Path, offset: float, no_auto_sync: bool,
             origin: str | None, destination: str | None, subtitle: str | None,
             road: str | None, crew: str | None, lockup: str | None,
             far_pin: bool = False,
+            intro_style: str = intro_styles.DEFAULT_STYLE,
+            intro_reveal_secs: float = 0.0,
             grade_look: str = "none", grade_strength: int = 35,
             grade_wb: str = "off"):
     """Full pipeline: detect → review → compose highlight videos.
@@ -606,6 +636,7 @@ def process(date_folder: Path, offset: float, no_auto_sync: bool,
             origin=fields["origin"], destination=fields["destination"],
             subtitle=fields["subtitle"], road=fields["road"],
             crew=fields["crew"], lockup=lockup, far_pin=far_pin,
+            intro_style=intro_style, intro_reveal_secs=intro_reveal_secs,
             grade_look=grade_look, grade_strength=grade_strength,
             grade_wb=grade_wb,
         )
@@ -621,6 +652,8 @@ def _process_body(date_folder: Path, offset: float, no_auto_sync: bool,
                   subtitle: str | None = None, road: str | None = None,
                   crew: str | None = None, lockup: str | None = None,
                   far_pin: bool = False,
+                  intro_style: str = intro_styles.DEFAULT_STYLE,
+                  intro_reveal_secs: float = 0.0,
                   grade_look: str = "none", grade_strength: int = 35,
                   grade_wb: str = "off"):
     """Body of `process` — extracted so caffeinate wraps the whole run."""
@@ -676,6 +709,8 @@ def _process_body(date_folder: Path, offset: float, no_auto_sync: bool,
         crew=crew,
         lockup=lockup,
         far_pin=far_pin,
+        intro_style=intro_style,
+        intro_reveal_secs=intro_reveal_secs,
         grade_look=grade_look,
         grade_strength=grade_strength / 100,
         grade_wb=grade_wb,
@@ -876,12 +911,15 @@ def review_candidates(video_dir: Path, fit_file: Path, labels_file: Path | None,
               "apex/turnaround) instead of where the ride ended. Use when you trained "
               "or drove home from a different town than the real destination.")
 @_grade_options
+@_intro_options
 def compose_selected(selections_file: Path, video_dir: Path, fit_file: Path,
                      output_dir: Path | None, offset: float, no_auto_sync: bool,
                      layout: str, preview: bool, trim: float,
                      origin: str | None, destination: str | None, subtitle: str | None,
                      road: str | None, crew: str | None, lockup: str | None,
                      far_pin: bool = False,
+                     intro_style: str = intro_styles.DEFAULT_STYLE,
+                     intro_reveal_secs: float = 0.0,
                      grade_look: str = "none", grade_strength: int = 35,
                      grade_wb: str = "off"):
     """Compose a highlight video from hand-picked candidate selections.
@@ -921,6 +959,7 @@ def compose_selected(selections_file: Path, video_dir: Path, fit_file: Path,
             origin=fields["origin"], destination=fields["destination"],
             subtitle=fields["subtitle"], road=fields["road"],
             crew=fields["crew"], lockup=lockup, far_pin=far_pin,
+            intro_style=intro_style, intro_reveal_secs=intro_reveal_secs,
             grade_look=grade_look, grade_strength=grade_strength / 100,
             grade_wb=grade_wb,
         )

--- a/src/gopro_garmin_pipeline/intro_styles.py
+++ b/src/gopro_garmin_pipeline/intro_styles.py
@@ -342,7 +342,24 @@ def _signal(src: str, dst: str, secs: float, g: Geom) -> list[str]:
             f"noise=alls={rng.randint(14, 30)}:allf=t"
             f":enable='between(t,{t0:.3f},{t0 + rng.uniform(0.03, 0.08):.3f})'"
         )
-    chains.append("[sgmosaic]" + ",".join(parts) + dst)
+    # rgbashift only accepts RGB, so leaving it inline costs a
+    # yuv420p→gbrp→yuv420p round-trip on EVERY frame of the clip — `enable=`
+    # gates the filter, not the format conversion swscale negotiates around
+    # it. That is permanent 4:2:0 chroma loss (measured: post-reveal PSNR
+    # u:41 v:39 against the source, versus `inf` for every other style), and
+    # since the intro only runs on segment 0 it shows up as a visible quality
+    # step at the first cut.
+    #
+    # So the effect runs on its own branch, `trim`med to the reveal window,
+    # and is overlaid back. eof_action=pass hands the clean branch straight
+    # through once the trimmed branch ends: after the reveal the graph is a
+    # genuine no-op, and the RGB conversion only ever touches reveal frames.
+    chains.append("[sgmosaic]split=2[sgclean][sgfx]")
+    chains.append(
+        f"[sgfx]trim=end={secs:.3f},setpts=PTS-STARTPTS,"
+        + ",".join(parts) + ",format=yuva420p[sgfxo]"
+    )
+    chains.append(f"[sgclean][sgfxo]overlay=0:0:eof_action=pass:format=auto{dst}")
     return chains
 
 


### PR DESCRIPTION
Two fixes from a code review of #7.

## 1. `signal` degraded chroma on the whole first clip

`rgbashift` only accepts RGB pixel formats, so leaving it inline cost a `yuv420p→gbrp→yuv420p` round-trip on **every frame of the clip**, not just the gated reveal window — `enable=` gates the filter, not the format negotiation swscale inserts around it. Since `signal` is `DEFAULT_STYLE` and the intro only runs on segment 0, this was a visible quality step at the first cut, and it contradicted the module docstring's claim that the graph passes through untouched once the reveal is done.

The effect now runs on its own `split` branch, `trim`med to the reveal window, and is overlaid back with `eof_action=pass` so the clean branch flows straight through once the trimmed branch ends.

Measured by rendering to `yuv420p` files and PSNR-ing the post-reveal tail against a plain render of the same source:

| | before | after |
|---|---|---|
| 1080p | `y:52.49 u:41.49 v:39.38` | `inf` (bit-exact) |
| 4K | `y:53.29 u:42.93 v:39.82` | `inf` (bit-exact) |

The reveal itself is unchanged — old vs. new over the reveal head PSNRs at ~64 dB, well past visually lossless. 4K render time also went 8.4s → 7.0s.

## 2. `--intro-style` never reached the reel pipeline

The flags were wired only into the `burn` subcommand. The README tells users to swap styles with `--intro-style`, but `ComposerConfig(...)` and `compose_from_selections(...)` were never given them — anyone running the documented pipeline was locked to `signal`.

Adds an `_intro_options` decorator mirroring the existing `_grade_options`, applied to `compose`, `process`, and `compose-selected`. Verified with mocked composer entry points that values land: `compose → ('punch', 2.5)`, `process → ('mosaic', 1.1)`, `compose-selected → ('scan', 0.9)`.

Incidentally this surfaces the previously-dead `describe()` output in `--intro-style` help, and `click.Choice` now rejects typos before they reach the unfriendly `KeyError` path.

## Testing

- All five styles build and render at 1080p and 4K; four were already bit-exact after the reveal and stay that way.
- `pytest`: 79 passed, 4 failed — the 4 are a pre-existing missing `openai` package, confirmed by stashing these changes.
- `ruff check src/`: clean.

## Not addressed

Three lower-severity findings from the same review remain open: `intro_reveal_secs` is unclamped against `intro_secs`, the `signal` mask grid drifts out of alignment with the pixelize grid, and the contiguous `between()` windows double-apply on boundary frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)