### PR TITLE
Fix/windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ src/gopro_garmin_pipeline/design/proposals/
 moments.json
 ride_labels.json
 .vscode
+.streamlit/
 
 # The published sample ride is the exception: its sidecars are committed so
 # the labels and baseline ratings are readable without downloading video.

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ src/gopro_garmin_pipeline/design/proposals/
 .local_cache/
 moments.json
 ride_labels.json
+.vscode
 
 # The published sample ride is the exception: its sidecars are committed so
 # the labels and baseline ratings are readable without downloading video.

--- a/README.md
+++ b/README.md
@@ -359,7 +359,7 @@ tests/                # Smoke tests
 ## Caveats
 
 * **Built for one setup**: GoPro Hero 13 + Garmin Edge 540 + road cycling. Other cameras and head units should work (GPMF sync reads the standard telemetry track), but are untested.
-* **I only tested on macOS**: should work for Linux but I haven't tested yet.
+* **I only tested on macOS**: should work for Windows and Linux but I haven't fully tested yet.
 * **The learned ranker is WIP.** `learned_ranker.py` logs training data on every compose and will fit a logistic regression at ~100 examples. I never reached the threshold before the feature schema went stale. It's honest to call it unfinished.
 * Video and FIT files are gitignored.
 

--- a/src/gopro_garmin_pipeline/burn_overlay.py
+++ b/src/gopro_garmin_pipeline/burn_overlay.py
@@ -847,8 +847,11 @@ class OverlayRenderer:
         if self._intro_origin is None:
             self._intro_origin = video_secs
             local = self._local_wall(video_secs)
-            # %-I / %-M strip the leading zero (POSIX). "3:06 PM".
-            self._intro_time_str = local.strftime("%-I:%M %p")
+            # Windows does not support the POSIX %-I / %-M strftime flags,
+            # so format the hour/minute explicitly to keep the timestamp
+            # readable as "3:06 PM" instead of "03:06 PM".
+            hour_12 = local.hour % 12 or 12
+            self._intro_time_str = f"{hour_12}:{local.minute:02d} {local.strftime('%p')}"
             self._intro_date_str = local.strftime("%b %d, %Y").upper()
         rel = video_secs - self._intro_origin
         if rel >= self.intro_secs:

--- a/src/gopro_garmin_pipeline/burn_overlay.py
+++ b/src/gopro_garmin_pipeline/burn_overlay.py
@@ -23,6 +23,7 @@ import datetime as dt
 import io
 import math
 import subprocess
+import sys
 import urllib.request
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -963,7 +964,9 @@ ENCODE_MASTER = "master"
 def _encode_args(preset: str) -> list[str]:
     """Return ffmpeg encoding arguments for the given preset.
 
-    preview: VideoToolbox hardware encoder, fast, larger files.
+    preview: a fast default that stays compatible with the current OS. On macOS
+    the native VideoToolbox encoder is available, but Windows/Linux must use a
+    cross-platform encoder such as libx264 or ffmpeg rejects the command.
     master:  libx264 software encoder, high quality, +faststart for web.
     """
     if preset == ENCODE_MASTER:
@@ -973,10 +976,16 @@ def _encode_args(preset: str) -> list[str]:
             "-pix_fmt", "yuv420p",
             "-movflags", "+faststart",
         ]
-    # Default: preview (fast hardware encode)
+    if sys.platform.startswith("darwin"):
+        return [
+            "-c:v", "h264_videotoolbox", "-q:v", "65",
+            "-c:a", "copy", "-pix_fmt", "yuv420p",
+        ]
     return [
-        "-c:v", "h264_videotoolbox", "-q:v", "65",
-        "-c:a", "copy", "-pix_fmt", "yuv420p",
+        "-c:v", "libx264", "-preset", "veryfast", "-crf", "23",
+        "-c:a", "aac", "-b:a", "192k",
+        "-pix_fmt", "yuv420p",
+        "-movflags", "+faststart",
     ]
 
 

--- a/src/gopro_garmin_pipeline/prompt_registry.py
+++ b/src/gopro_garmin_pipeline/prompt_registry.py
@@ -30,7 +30,7 @@ def _prompt_path(name: str, version: str) -> Path:
 def load_prompt(name: str, version: str) -> tuple[dict, str]:
     """Return (metadata, body) for a named, versioned prompt."""
     path = _prompt_path(name, version)
-    raw = path.read_text()
+    raw = path.read_text(encoding='utf-8')
     if not raw.startswith(_FM_DELIM):
         raise ValueError(f"{path}: missing TOML frontmatter (+++)")
     _, fm, body = raw.split(_FM_DELIM, 2)

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -8,14 +8,25 @@ classifier. Everything here runs in well under a second.
 from __future__ import annotations
 
 import math
+import sys
 
 import pytest
 
+from gopro_garmin_pipeline.burn_overlay import ENCODE_PREVIEW, _encode_args
 from gopro_garmin_pipeline.config import Settings
 from gopro_garmin_pipeline.design import tokens as T
 from gopro_garmin_pipeline import route_metadata as rm
 from gopro_garmin_pipeline import prompt_eval as pe
 from gopro_garmin_pipeline.utils import rating_visual_action
+
+
+# ─── FFmpeg encoders ─────────────────────────────────────────
+
+def test_preview_encode_args_use_compatible_encoder():
+    args = _encode_args(ENCODE_PREVIEW)
+    assert "libx264" in args
+    assert "h264_videotoolbox" not in args
+    assert sys.platform.startswith("win") or "libx264" in args
 
 
 # ─── Config ───────────────────────────────────────────────────

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -24,10 +24,12 @@ from gopro_garmin_pipeline.utils import rating_visual_action
 
 def test_preview_encode_args_use_compatible_encoder():
     args = _encode_args(ENCODE_PREVIEW)
-    assert "libx264" in args
-    assert "h264_videotoolbox" not in args
-    assert sys.platform.startswith("win") or "libx264" in args
-
+    if sys.platform.startswith("darwin"):
+        assert "h264_videotoolbox" in args
+        assert "libx264" not in args
+    else:
+        assert "libx264" in args
+        assert "h264_videotoolbox" not in args
 
 # ─── Config ───────────────────────────────────────────────────
 


### PR DESCRIPTION
Had to make a few tweaks for this to run on my Windows laptop:
- Specify UTF-8 text encoding
- Update timestamp formatting
- Include a Windows ffmpeg encoder
- Add some Windows-specific directories to the gitignore and update the readme

I tried to make sure this doesn't break the existing Mac compatibility, but don't have a Mac to confirm